### PR TITLE
Issue #13: Add link expansion for generated HTML

### DIFF
--- a/client/channels.go
+++ b/client/channels.go
@@ -19,8 +19,9 @@ import (
 
 // Channels はチャンネルデータの管理を行います。
 type Channels struct {
-	basedir  string
-	authorID string
+	basedir        string
+	authorID       string
+	previewFetcher linkPreviewFetchFunc
 }
 
 const (
@@ -30,7 +31,11 @@ const (
 
 // NewChannels は Channels 構造体の新しいインスタンスを作成します。
 func NewChannels(basedir, authorID string) (*Channels, error) {
-	return &Channels{basedir: basedir, authorID: authorID}, nil
+	return &Channels{
+		basedir:        basedir,
+		authorID:       authorID,
+		previewFetcher: defaultLinkPreviewFetcher,
+	}, nil
 }
 
 func (c *Channels) AppendMessage(ctx context.Context, channelName, jsonstring string, gdrive *GDrive) error {
@@ -106,6 +111,7 @@ func (c *Channels) CreateHtmlFile(ctx context.Context, channelName string, gdriv
 	if err != nil {
 		return err
 	}
+	contents = c.attachLinkPreviews(ctx, contents)
 
 	// テンプレートエンジンに適用
 	values := map[string]interface{}{
@@ -159,10 +165,11 @@ func parseEntriesFromJSONL(r io.Reader) ([]Entry, error) {
 
 // Entry jsonlファイルのデータ読み込み用構造体
 type Entry struct {
-	Timestamp string   `json:"timestamp"`
-	Message   string   `json:"message"`
-	Channel   Channel  `json:"channel"`
-	Files     []string `json:"files"`
+	Timestamp string       `json:"timestamp"`
+	Message   string       `json:"message"`
+	Channel   Channel      `json:"channel"`
+	Files     []string     `json:"files"`
+	Preview   *LinkPreview `json:"-"`
 }
 
 // Channel はメッセージが投稿されたチャンネル情報です。
@@ -171,21 +178,90 @@ type Channel struct {
 	Name string `json:"name"`
 }
 
-// 正規表現をコンパイル
-var re = regexp.MustCompile(`&lt;https?://[^\s]+&gt;`)
+// Slack形式のリンクトークン(<https://example.com|label>)を抽出する。
+var slackLinkTokenRe = regexp.MustCompile(`<https?://[^>\s]+(?:\|[^>\n]+)?>`)
 
 // MessageWithLinkTag メッセージに含まれるリンクをHTMLタグに変換
 func (e Entry) MessageWithLinkTag() template.HTML {
-	if strings.Contains(e.Message, "\u003chttp") {
-
-		// 文字列を置換
-		result := re.ReplaceAllStringFunc(template.HTMLEscapeString(e.Message), func(url string) string {
-			tmp := url[len("&lt;") : len(url)-len("&gt;")]
-			return fmt.Sprintf("<a href=\"%s\" target=\"_blank\">%s</a>", tmp, tmp)
-		})
-		return template.HTML(result)
-	} else {
+	matches := slackLinkTokenRe.FindAllStringIndex(e.Message, -1)
+	if len(matches) == 0 {
 		return template.HTML(template.HTMLEscapeString(e.Message))
+	}
+
+	var b strings.Builder
+	last := 0
+	for _, match := range matches {
+		b.WriteString(template.HTMLEscapeString(e.Message[last:match[0]]))
+		token := e.Message[match[0]:match[1]]
+		b.WriteString(slackLinkTokenToHTML(token))
+		last = match[1]
+	}
+	b.WriteString(template.HTMLEscapeString(e.Message[last:]))
+	return template.HTML(b.String())
+}
+
+// LinkURLs はメッセージ中のSlackリンクトークンからURLを抽出する。
+func (e Entry) LinkURLs() []string {
+	matches := slackLinkTokenRe.FindAllString(e.Message, -1)
+	if len(matches) == 0 {
+		return nil
+	}
+	urls := make([]string, 0, len(matches))
+	for _, token := range matches {
+		parsed := parseSlackLinkToken(token)
+		if parsed.URL != "" {
+			urls = append(urls, parsed.URL)
+		}
+	}
+	return urls
+}
+
+// IsLinkOnlyMessage は、空白を除いてSlackリンクトークンのみで構成されるメッセージかを判定する。
+func (e Entry) IsLinkOnlyMessage() bool {
+	message := strings.TrimSpace(e.Message)
+	if message == "" {
+		return false
+	}
+
+	matches := slackLinkTokenRe.FindAllStringIndex(message, -1)
+	if len(matches) == 0 {
+		return false
+	}
+
+	last := 0
+	for _, match := range matches {
+		if strings.TrimSpace(message[last:match[0]]) != "" {
+			return false
+		}
+		last = match[1]
+	}
+	return strings.TrimSpace(message[last:]) == ""
+}
+
+func slackLinkTokenToHTML(token string) string {
+	parsed := parseSlackLinkToken(token)
+	linkText := parsed.URL
+	if strings.TrimSpace(parsed.Label) != "" {
+		linkText = parsed.Label
+	}
+	return fmt.Sprintf(
+		"<a href=\"%s\" target=\"_blank\" rel=\"noopener noreferrer\">%s</a>",
+		template.HTMLEscapeString(parsed.URL),
+		template.HTMLEscapeString(linkText),
+	)
+}
+
+type slackLinkToken struct {
+	URL   string
+	Label string
+}
+
+func parseSlackLinkToken(token string) slackLinkToken {
+	raw := token[1 : len(token)-1]
+	url, label, _ := strings.Cut(raw, "|")
+	return slackLinkToken{
+		URL:   url,
+		Label: label,
 	}
 }
 

--- a/client/channels_test.go
+++ b/client/channels_test.go
@@ -21,8 +21,11 @@ func TestEntry_MessageWithLinkTag(t *testing.T) {
 		want   template.HTML
 	}{
 		{name: "no link", fields: fields{Message: "no link"}, want: "no link"},
-		{name: "one link", fields: fields{Message: "a\u003chttps://example.com/index.html\u003e"}, want: "a<a href=\"https://example.com/index.html\" target=\"_blank\">https://example.com/index.html</a>"},
-		{name: "two links", fields: fields{Message: "a\u003chttps://example.com/index.html\u003e b\u003chttps://example.com/index.html\u003e"}, want: "a<a href=\"https://example.com/index.html\" target=\"_blank\">https://example.com/index.html</a> b<a href=\"https://example.com/index.html\" target=\"_blank\">https://example.com/index.html</a>"},
+		{name: "one link", fields: fields{Message: "a\u003chttps://example.com/index.html\u003e"}, want: "a<a href=\"https://example.com/index.html\" target=\"_blank\" rel=\"noopener noreferrer\">https://example.com/index.html</a>"},
+		{name: "two links", fields: fields{Message: "a\u003chttps://example.com/index.html\u003e b\u003chttps://example.com/index.html\u003e"}, want: "a<a href=\"https://example.com/index.html\" target=\"_blank\" rel=\"noopener noreferrer\">https://example.com/index.html</a> b<a href=\"https://example.com/index.html\" target=\"_blank\" rel=\"noopener noreferrer\">https://example.com/index.html</a>"},
+		{name: "link with label", fields: fields{Message: "\u003chttps://example.com|example\u003e"}, want: "<a href=\"https://example.com\" target=\"_blank\" rel=\"noopener noreferrer\">example</a>"},
+		{name: "text escaped with link", fields: fields{Message: "x < y \u003chttps://example.com|z\u003e"}, want: "x &lt; y <a href=\"https://example.com\" target=\"_blank\" rel=\"noopener noreferrer\">z</a>"},
+		{name: "label escaped", fields: fields{Message: "\u003chttps://example.com|a&b\u003e"}, want: "<a href=\"https://example.com\" target=\"_blank\" rel=\"noopener noreferrer\">a&amp;b</a>"},
 		{name: "><><", fields: fields{Message: "><><"}, want: template.HTML(template.HTMLEscapeString("><><"))},
 	}
 	for _, tt := range tests {
@@ -35,6 +38,30 @@ func TestEntry_MessageWithLinkTag(t *testing.T) {
 			}
 			if got := e.MessageWithLinkTag(); got != tt.want {
 				t.Errorf("MessageWithLinkTag() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEntry_IsLinkOnlyMessage(t *testing.T) {
+	tests := []struct {
+		name    string
+		message string
+		want    bool
+	}{
+		{name: "single link", message: "<https://example.com>", want: true},
+		{name: "single link with label", message: "<https://example.com|example>", want: true},
+		{name: "multiple links with spaces", message: " <https://a.example>  <https://b.example|b> ", want: true},
+		{name: "text and link", message: "note <https://example.com>", want: false},
+		{name: "no link", message: "hello", want: false},
+		{name: "empty", message: "   ", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := Entry{Message: tt.message}
+			if got := e.IsLinkOnlyMessage(); got != tt.want {
+				t.Errorf("IsLinkOnlyMessage() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/client/link_preview.go
+++ b/client/link_preview.go
@@ -1,0 +1,295 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"net/netip"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"golang.org/x/net/html"
+)
+
+const (
+	linkPreviewTimeout       = 5 * time.Second
+	linkPreviewMaxRedirects  = 5
+	linkPreviewMaxBodyBytes  = 1 << 20
+	linkPreviewUserAgentName = "happeninghound-link-preview/1.0"
+)
+
+var (
+	cgnatPrefix = netip.MustParsePrefix("100.64.0.0/10")
+)
+
+type linkPreviewFetchFunc func(ctx context.Context, rawURL string) (*LinkPreview, error)
+
+type LinkPreview struct {
+	URL         string
+	Title       string
+	Description string
+	ImageURL    string
+	SiteName    string
+}
+
+func (c *Channels) attachLinkPreviews(ctx context.Context, entries []Entry) []Entry {
+	type cachedPreview struct {
+		preview *LinkPreview
+		err     error
+	}
+	cache := map[string]cachedPreview{}
+
+	for i := range entries {
+		if !entries[i].IsLinkOnlyMessage() {
+			continue
+		}
+		urls := entries[i].LinkURLs()
+		if len(urls) != 1 {
+			continue
+		}
+
+		cached, ok := cache[urls[0]]
+		if !ok {
+			preview, err := c.previewFetcher(ctx, urls[0])
+			cached = cachedPreview{
+				preview: preview,
+				err:     err,
+			}
+			cache[urls[0]] = cached
+		}
+
+		if cached.err != nil {
+			log.Printf("link preview取得をスキップ: url=%s err=%v", urls[0], cached.err)
+			continue
+		}
+		if cached.preview == nil {
+			log.Printf("link preview取得をスキップ: url=%s err=%v", urls[0], errors.New("empty preview"))
+			continue
+		}
+		entries[i].Preview = cached.preview
+	}
+	return entries
+}
+
+func defaultLinkPreviewFetcher(ctx context.Context, rawURL string) (*LinkPreview, error) {
+	parsedURL, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, fmt.Errorf("URL parse failed: %w", err)
+	}
+	if err := validatePreviewURL(ctx, parsedURL); err != nil {
+		return nil, err
+	}
+
+	client := &http.Client{
+		Timeout:   linkPreviewTimeout,
+		Transport: previewHTTPTransport(),
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if len(via) >= linkPreviewMaxRedirects {
+				return errors.New("too many redirects")
+			}
+			return validatePreviewURL(req.Context(), req.URL)
+		},
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, parsedURL.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("request creation failed: %w", err)
+	}
+	req.Header.Set("User-Agent", linkPreviewUserAgentName)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("unexpected status: %d", resp.StatusCode)
+	}
+
+	preview, err := parseLinkPreviewFromHTML(resp.Request.URL, io.LimitReader(resp.Body, linkPreviewMaxBodyBytes))
+	if err != nil {
+		return nil, err
+	}
+	if preview == nil {
+		return nil, errors.New("no preview metadata")
+	}
+	return preview, nil
+}
+
+func validatePreviewURL(ctx context.Context, u *url.URL) error {
+	if u == nil {
+		return errors.New("nil URL")
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("unsupported scheme: %s", u.Scheme)
+	}
+	host := u.Hostname()
+	if host == "" {
+		return errors.New("empty hostname")
+	}
+	if strings.EqualFold(host, "localhost") {
+		return errors.New("localhost is blocked")
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		if isBlockedIP(ip) {
+			return fmt.Errorf("private address is blocked: %s", ip.String())
+		}
+		if err := validatePort(u.Port()); err != nil {
+			return err
+		}
+		return nil
+	}
+	if err := validatePort(u.Port()); err != nil {
+		return err
+	}
+	ips, err := net.DefaultResolver.LookupIP(ctx, "ip", host)
+	if err != nil {
+		return fmt.Errorf("DNS lookup failed: %w", err)
+	}
+	for _, ip := range ips {
+		if isBlockedIP(ip) {
+			return fmt.Errorf("private address is blocked: %s", ip.String())
+		}
+	}
+	return nil
+}
+
+func previewHTTPTransport() *http.Transport {
+	base := http.DefaultTransport.(*http.Transport).Clone()
+	dialer := &net.Dialer{Timeout: linkPreviewTimeout}
+	base.DialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
+		conn, err := dialer.DialContext(ctx, network, address)
+		if err != nil {
+			return nil, err
+		}
+
+		host, _, splitErr := net.SplitHostPort(conn.RemoteAddr().String())
+		if splitErr != nil {
+			_ = conn.Close()
+			return nil, splitErr
+		}
+		ip := net.ParseIP(host)
+		if ip == nil {
+			_ = conn.Close()
+			return nil, fmt.Errorf("remote ip parse failed: %s", host)
+		}
+		if isBlockedIP(ip) {
+			_ = conn.Close()
+			return nil, fmt.Errorf("private address is blocked: %s", ip.String())
+		}
+		return conn, nil
+	}
+	return base
+}
+
+func validatePort(port string) error {
+	if port == "" {
+		return nil
+	}
+	n, err := strconv.Atoi(port)
+	if err != nil || n <= 0 || n > 65535 {
+		return fmt.Errorf("invalid port: %s", port)
+	}
+	return nil
+}
+
+func isBlockedIP(ip net.IP) bool {
+	if ip == nil {
+		return true
+	}
+	if ip.IsPrivate() || ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsUnspecified() || ip.IsMulticast() {
+		return true
+	}
+
+	addr, ok := netip.AddrFromSlice(ip)
+	if !ok {
+		return true
+	}
+	return cgnatPrefix.Contains(addr.Unmap())
+}
+
+func parseLinkPreviewFromHTML(pageURL *url.URL, r io.Reader) (*LinkPreview, error) {
+	z := html.NewTokenizer(r)
+	og := map[string]string{}
+	var title string
+
+	for {
+		tt := z.Next()
+		switch tt {
+		case html.ErrorToken:
+			err := z.Err()
+			if err == io.EOF {
+				return buildLinkPreview(pageURL, title, og), nil
+			}
+			return nil, fmt.Errorf("HTML parse failed: %w", err)
+		case html.StartTagToken, html.SelfClosingTagToken:
+			token := z.Token()
+			switch token.Data {
+			case "meta":
+				var key string
+				var content string
+				for _, attr := range token.Attr {
+					switch strings.ToLower(attr.Key) {
+					case "property", "name":
+						key = strings.ToLower(strings.TrimSpace(attr.Val))
+					case "content":
+						content = strings.TrimSpace(attr.Val)
+					}
+				}
+				if key != "" && content != "" {
+					og[key] = content
+				}
+			case "title":
+				if title == "" && z.Next() == html.TextToken {
+					title = strings.TrimSpace(z.Token().Data)
+				}
+			}
+		}
+	}
+}
+
+func buildLinkPreview(pageURL *url.URL, title string, og map[string]string) *LinkPreview {
+	resolvedTitle := firstNonEmpty(og["og:title"], title)
+	description := firstNonEmpty(og["og:description"], og["description"])
+	image := firstNonEmpty(og["og:image"], og["image"])
+	siteName := firstNonEmpty(og["og:site_name"], og["twitter:site"])
+
+	if resolvedTitle == "" && description == "" && image == "" && siteName == "" {
+		return nil
+	}
+
+	imageURL := image
+	if image != "" && pageURL != nil {
+		if imageParsed, err := url.Parse(image); err == nil {
+			imageURL = pageURL.ResolveReference(imageParsed).String()
+		}
+	}
+
+	page := ""
+	if pageURL != nil {
+		page = pageURL.String()
+	}
+
+	return &LinkPreview{
+		URL:         page,
+		Title:       resolvedTitle,
+		Description: description,
+		ImageURL:    imageURL,
+		SiteName:    siteName,
+	}
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if strings.TrimSpace(v) != "" {
+			return strings.TrimSpace(v)
+		}
+	}
+	return ""
+}

--- a/client/link_preview_test.go
+++ b/client/link_preview_test.go
@@ -1,0 +1,158 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestAttachLinkPreviews(t *testing.T) {
+	calls := 0
+	ch := &Channels{
+		previewFetcher: func(_ context.Context, rawURL string) (*LinkPreview, error) {
+			calls++
+			return &LinkPreview{
+				URL:   rawURL,
+				Title: "preview-title",
+			}, nil
+		},
+	}
+
+	entries := []Entry{
+		{Message: "<https://example.com>"},
+		{Message: "<https://example.com|same>"},
+		{Message: "text <https://example.com>"},
+		{Message: "<https://a.example> <https://b.example>"},
+	}
+
+	got := ch.attachLinkPreviews(context.Background(), entries)
+	if got[0].Preview == nil || got[0].Preview.Title != "preview-title" {
+		t.Fatalf("entry[0] preview not set: %+v", got[0].Preview)
+	}
+	if got[1].Preview == nil || got[1].Preview.Title != "preview-title" {
+		t.Fatalf("entry[1] preview not set: %+v", got[1].Preview)
+	}
+	if got[2].Preview != nil {
+		t.Fatalf("entry[2] preview should be nil: %+v", got[2].Preview)
+	}
+	if got[3].Preview != nil {
+		t.Fatalf("entry[3] preview should be nil: %+v", got[3].Preview)
+	}
+	if calls != 1 {
+		t.Fatalf("preview fetcher calls = %d, want 1", calls)
+	}
+}
+
+func TestParseLinkPreviewFromHTML(t *testing.T) {
+	pageURL, err := url.Parse("https://example.com/posts/1")
+	if err != nil {
+		t.Fatalf("url parse failed: %v", err)
+	}
+
+	html := `
+<!doctype html>
+<html>
+<head>
+  <title>Fallback Title</title>
+  <meta property="og:title" content="OG Title">
+  <meta property="og:description" content="OG Desc">
+  <meta property="og:image" content="/images/cover.png">
+  <meta property="og:site_name" content="Example Site">
+</head>
+<body></body>
+</html>`
+
+	preview, err := parseLinkPreviewFromHTML(pageURL, strings.NewReader(html))
+	if err != nil {
+		t.Fatalf("parseLinkPreviewFromHTML() error = %v", err)
+	}
+	if preview == nil {
+		t.Fatal("preview is nil")
+	}
+	if preview.Title != "OG Title" {
+		t.Errorf("Title = %q, want %q", preview.Title, "OG Title")
+	}
+	if preview.Description != "OG Desc" {
+		t.Errorf("Description = %q, want %q", preview.Description, "OG Desc")
+	}
+	if preview.ImageURL != "https://example.com/images/cover.png" {
+		t.Errorf("ImageURL = %q, want %q", preview.ImageURL, "https://example.com/images/cover.png")
+	}
+	if preview.SiteName != "Example Site" {
+		t.Errorf("SiteName = %q, want %q", preview.SiteName, "Example Site")
+	}
+}
+
+func TestBuildLinkPreview_NoMetadata(t *testing.T) {
+	pageURL, err := url.Parse("https://example.com")
+	if err != nil {
+		t.Fatalf("url parse failed: %v", err)
+	}
+	got := buildLinkPreview(pageURL, "", map[string]string{})
+	if got != nil {
+		t.Fatalf("buildLinkPreview() = %+v, want nil", got)
+	}
+}
+
+func TestValidatePreviewURL(t *testing.T) {
+	tests := []struct {
+		name      string
+		rawURL    string
+		wantError bool
+	}{
+		{name: "https public ip", rawURL: "https://8.8.8.8", wantError: false},
+		{name: "http public ip", rawURL: "http://1.1.1.1", wantError: false},
+		{name: "unsupported scheme", rawURL: "ftp://example.com", wantError: true},
+		{name: "localhost blocked", rawURL: "https://localhost/path", wantError: true},
+		{name: "loopback blocked", rawURL: "https://127.0.0.1/path", wantError: true},
+		{name: "invalid port blocked", rawURL: "https://1.1.1.1:99999/path", wantError: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parsed, err := url.Parse(tt.rawURL)
+			if err != nil {
+				t.Fatalf("url parse failed: %v", err)
+			}
+			err = validatePreviewURL(context.Background(), parsed)
+			if tt.wantError && err == nil {
+				t.Fatalf("validatePreviewURL() error = nil, want error")
+			}
+			if !tt.wantError && err != nil {
+				t.Fatalf("validatePreviewURL() error = %v, want nil", err)
+			}
+		})
+	}
+}
+
+func TestValidatePort(t *testing.T) {
+	tests := []struct {
+		port      string
+		wantError bool
+	}{
+		{port: "", wantError: false},
+		{port: "443", wantError: false},
+		{port: "0", wantError: true},
+		{port: "70000", wantError: true},
+		{port: "abc", wantError: true},
+	}
+	for _, tt := range tests {
+		err := validatePort(tt.port)
+		if tt.wantError && err == nil {
+			t.Fatalf("validatePort(%q) error=nil, want error", tt.port)
+		}
+		if !tt.wantError && err != nil {
+			t.Fatalf("validatePort(%q) error=%v, want nil", tt.port, err)
+		}
+	}
+}
+
+func TestEntry_LinkURLs(t *testing.T) {
+	e := Entry{Message: "a <https://example.com|ex> b <https://example.org>"}
+	got := e.LinkURLs()
+	want := []string{"https://example.com", "https://example.org"}
+	if fmt.Sprintf("%v", got) != fmt.Sprintf("%v", want) {
+		t.Fatalf("LinkURLs() = %v, want %v", got, want)
+	}
+}

--- a/client/template/happeninghound-viewer.html
+++ b/client/template/happeninghound-viewer.html
@@ -16,6 +16,22 @@
     <div class="p-4">
         <p class="mb-1 text-sm text-primary-500"><time>{{ $v.Timestamp2String }}</time></p>
         <p class="mt-1 text-gray-500">{{ $v.MessageWithLinkTag }}</p>
+        {{ if $v.Preview }}
+        <a href="{{ $v.Preview.URL }}" target="_blank" rel="noopener noreferrer" class="mt-3 block rounded border border-gray-200 p-3 hover:bg-gray-50">
+            {{ if $v.Preview.ImageURL }}
+            <img src="{{ $v.Preview.ImageURL }}" class="mb-2 aspect-video w-full rounded object-cover" alt="" />
+            {{ end }}
+            {{ if $v.Preview.SiteName }}
+            <p class="text-xs text-gray-400">{{ $v.Preview.SiteName }}</p>
+            {{ end }}
+            {{ if $v.Preview.Title }}
+            <p class="text-sm font-medium text-gray-700">{{ $v.Preview.Title }}</p>
+            {{ end }}
+            {{ if $v.Preview.Description }}
+            <p class="mt-1 text-sm text-gray-500">{{ $v.Preview.Description }}</p>
+            {{ end }}
+        </a>
+        {{ end }}
     </div>
     {{ range $v.Files }}
     <img src="../{{ . }}" class="aspect-video w-full object-cover" alt="" />


### PR DESCRIPTION
## Summary
- improve Slack link parsing for <url> and <url|label> formats
- add link-only message detection and convert links safely with escaped text
- fetch OGP metadata during /make-html generation and render preview cards in the viewer template
- add preview fetch safeguards (timeout, redirect limit, blocked local/private addresses) and per-run URL cache
- add unit tests for link conversion, link-only detection, preview parsing, URL validation, and cache behavior

Closes #13