### PR TITLE
test: expand coverage for issue #49

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 *.exe
 happeninghound
 happeninghound-*
+cover

--- a/client/channels_test.go
+++ b/client/channels_test.go
@@ -46,9 +46,12 @@ func TestEntry_Timestamp2String(t *testing.T) {
 		timestamp string
 		want      string
 	}{
+		{name: "valid timestamp 1digit", timestamp: "1633024800.1", want: "2021-09-30 18:00:00"},
+		{name: "valid timestamp 8digits", timestamp: "1633024800.12345678", want: "2021-09-30 18:00:00"},
 		{name: "valid timestamp 9digits", timestamp: "1633024800.123456789", want: "2021-09-30 18:00:00"},
 		{name: "valid timestamp 6digits", timestamp: "1633024800.123456", want: "2021-09-30 18:00:00"},
 		{name: "valid timestamp 10digits", timestamp: "1633024800.1234567890", want: "2021-09-30 18:00:00"},
+		{name: "invalid fractional timestamp", timestamp: "1633024800.abc", want: ""},
 		{name: "invalid timestamp", timestamp: "invalid.timestamp", want: ""},
 		{name: "no dot timestamp", timestamp: "1633024800", want: ""},
 	}

--- a/client/gdrive.go
+++ b/client/gdrive.go
@@ -13,11 +13,11 @@ import (
 )
 
 type GDrive struct {
-	client    *drive.Service
-	baseDir   string
-	targetDir *drive.File
-	imageDir  *drive.File
-	htmlDir   *drive.File
+	client          *drive.Service
+	baseDir         string
+	targetDir       *drive.File
+	imageDir        *drive.File
+	htmlDir         *drive.File
 	getTargetFileFn func(ctx context.Context, filename, dirid string) *drive.File
 	createFileFn    func(ctx context.Context, name, parent, filepath string) error
 	updateFileFn    func(ctx context.Context, name, id, filepath string) error

--- a/client/gdrive.go
+++ b/client/gdrive.go
@@ -18,6 +18,9 @@ type GDrive struct {
 	targetDir *drive.File
 	imageDir  *drive.File
 	htmlDir   *drive.File
+	getTargetFileFn func(ctx context.Context, filename, dirid string) *drive.File
+	createFileFn    func(ctx context.Context, name, parent, filepath string) error
+	updateFileFn    func(ctx context.Context, name, id, filepath string) error
 }
 
 func (g GDrive) htmlCreateParentID() string {
@@ -231,11 +234,11 @@ func (g GDrive) UploadFile(ctx context.Context, name string, filepath string) er
 	ctx, span := tracer.Start(ctx, "GDrive.UploadFile")
 	defer span.End()
 
-	f := g.getTargetFile(ctx, name, g.targetDir.Id)
+	f := g.targetFile(ctx, name, g.targetDir.Id)
 	if f == nil {
-		return g.createFile(ctx, name, g.targetDir.Id, filepath)
+		return g.createOrUpdateFile(ctx, name, g.targetDir.Id, "", filepath, true)
 	} else {
-		return g.updateFile(ctx, name, f.Id, filepath)
+		return g.createOrUpdateFile(ctx, name, "", f.Id, filepath, false)
 	}
 }
 
@@ -248,10 +251,30 @@ func (g GDrive) UploadHtmlFile(ctx context.Context, name string, filepath string
 	ctx, span := tracer.Start(ctx, "GDrive.UploadHtmlFile")
 	defer span.End()
 
-	f := g.getTargetFile(ctx, name, g.htmlDir.Id)
+	f := g.targetFile(ctx, name, g.htmlDir.Id)
 	if f == nil {
-		return g.createFile(ctx, name, g.htmlCreateParentID(), filepath)
+		return g.createOrUpdateFile(ctx, name, g.htmlCreateParentID(), "", filepath, true)
 	} else {
-		return g.updateFile(ctx, name, f.Id, filepath)
+		return g.createOrUpdateFile(ctx, name, "", f.Id, filepath, false)
 	}
+}
+
+func (g GDrive) targetFile(ctx context.Context, filename, dirid string) *drive.File {
+	if g.getTargetFileFn != nil {
+		return g.getTargetFileFn(ctx, filename, dirid)
+	}
+	return g.getTargetFile(ctx, filename, dirid)
+}
+
+func (g GDrive) createOrUpdateFile(ctx context.Context, name, parent, id, filepath string, create bool) error {
+	if create {
+		if g.createFileFn != nil {
+			return g.createFileFn(ctx, name, parent, filepath)
+		}
+		return g.createFile(ctx, name, parent, filepath)
+	}
+	if g.updateFileFn != nil {
+		return g.updateFileFn(ctx, name, id, filepath)
+	}
+	return g.updateFile(ctx, name, id, filepath)
 }

--- a/client/gdrive_test.go
+++ b/client/gdrive_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"go.opentelemetry.io/otel"
 	"google.golang.org/api/drive/v3"
 )
 
@@ -45,5 +46,67 @@ func TestGDrive_UploadHtmlFile_NilHtmlDir(t *testing.T) {
 	err := g.UploadHtmlFile(context.Background(), "index.html", "/tmp/index.html")
 	if err == nil {
 		t.Fatal("expected error when htmlDir is nil, got nil")
+	}
+}
+
+func TestGDrive_UploadHtmlFile_CreateUsesHtmlDirAsParent(t *testing.T) {
+	tracer = otel.GetTracerProvider().Tracer("client-test")
+
+	called := false
+	var gotParent string
+	g := GDrive{
+		htmlDir: &drive.File{Id: "html-dir-id"},
+		getTargetFileFn: func(ctx context.Context, filename, dirid string) *drive.File {
+			return nil
+		},
+		createFileFn: func(ctx context.Context, name, parent, filepath string) error {
+			called = true
+			gotParent = parent
+			return nil
+		},
+	}
+
+	if err := g.UploadHtmlFile(context.Background(), "index.html", "/tmp/index.html"); err != nil {
+		t.Fatalf("UploadHtmlFile() error = %v", err)
+	}
+	if !called {
+		t.Fatal("createFile was not called")
+	}
+	if gotParent != "html-dir-id" {
+		t.Fatalf("createFile parent = %q, want %q", gotParent, "html-dir-id")
+	}
+}
+
+func TestGDrive_UploadHtmlFile_UpdateWhenFileExists(t *testing.T) {
+	tracer = otel.GetTracerProvider().Tracer("client-test")
+
+	createCalled := false
+	updateCalled := false
+	g := GDrive{
+		htmlDir: &drive.File{Id: "html-dir-id"},
+		getTargetFileFn: func(ctx context.Context, filename, dirid string) *drive.File {
+			return &drive.File{Id: "existing-file-id", Name: filename}
+		},
+		createFileFn: func(ctx context.Context, name, parent, filepath string) error {
+			createCalled = true
+			return nil
+		},
+		updateFileFn: func(ctx context.Context, name, id, filepath string) error {
+			updateCalled = true
+			if id != "existing-file-id" {
+				t.Fatalf("updateFile id = %q, want %q", id, "existing-file-id")
+			}
+			return nil
+		},
+	}
+
+	if err := g.UploadHtmlFile(context.Background(), "index.html", "/tmp/index.html"); err != nil {
+		t.Fatalf("UploadHtmlFile() error = %v", err)
+	}
+	if createCalled {
+		t.Fatal("createFile should not be called when file exists")
+	}
+	if !updateCalled {
+		t.Fatal("updateFile was not called")
 	}
 }

--- a/client/handlers_test.go
+++ b/client/handlers_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/slack-go/slack"
 	"github.com/slack-go/slack/slackevents"
+	"github.com/slack-go/slack/socketmode"
 )
 
 func TestSlashCommandFromEventData(t *testing.T) {
@@ -43,6 +44,78 @@ func TestSlashCommandFromEventData(t *testing.T) {
 			_, ok := slashCommandFromEventData(tt.data)
 			if ok != tt.want {
 				t.Fatalf("slashCommandFromEventData() ok = %v, want %v", ok, tt.want)
+			}
+		})
+	}
+}
+
+func TestSkipMessage(t *testing.T) {
+	botMention := "<@B999>"
+	channels := &Channels{authorID: "U123"}
+	client := &socketmode.Client{}
+
+	tests := []struct {
+		name string
+		p    *slackevents.MessageEvent
+		want bool
+	}{
+		{
+			name: "skip bot mention",
+			p: &slackevents.MessageEvent{
+				Text: "<@B999> hello",
+				User: "U123",
+			},
+			want: true,
+		},
+		{
+			name: "skip not author",
+			p: &slackevents.MessageEvent{
+				Text: "hello",
+				User: "U999",
+			},
+			want: true,
+		},
+		{
+			name: "skip subtype not file_share",
+			p: &slackevents.MessageEvent{
+				Text:    "hello",
+				User:    "U123",
+				SubType: "message_changed",
+			},
+			want: true,
+		},
+		{
+			name: "skip empty text when not file_share",
+			p: &slackevents.MessageEvent{
+				Text:    "   ",
+				User:    "U123",
+				SubType: "",
+			},
+			want: true,
+		},
+		{
+			name: "allow file_share with empty text",
+			p: &slackevents.MessageEvent{
+				Text:    "   ",
+				User:    "U123",
+				SubType: "file_share",
+			},
+			want: false,
+		},
+		{
+			name: "allow normal message",
+			p: &slackevents.MessageEvent{
+				Text: "hello",
+				User: "U123",
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := skipMessage(tt.p, botMention, client, channels); got != tt.want {
+				t.Fatalf("skipMessage() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- add timestamp normalization edge cases to `Entry.Timestamp2String()` tests
- add branch-coverage tests for `skipMessage()` behavior
- add tests to verify `UploadHtmlFile()` create/update destination behavior
- introduce minimal internal hooks in `GDrive` to enable deterministic upload-path tests

## Verification
- `go test ./...`

Closes #49