### PR TITLE
Fix #67: prevent path traversal in /make-html

### DIFF
--- a/client/channels.go
+++ b/client/channels.go
@@ -99,7 +99,10 @@ func (c *Channels) CreateHtmlFile(ctx context.Context, channelName string, gdriv
 	ctx, span := tracer.Start(ctx, "CreateHtmlFile")
 	defer span.End()
 
-	filePath := c.createChannelFilePath(c.createChannelFileName(channelName))
+	filePath, err := c.safeJoinUnderBase(c.createChannelFileName(channelName))
+	if err != nil {
+		return fmt.Errorf("invalid channel path: %w", err)
+	}
 
 	//jsonl読み込み
 	f, err := os.Open(filePath)
@@ -123,7 +126,10 @@ func (c *Channels) CreateHtmlFile(ctx context.Context, channelName string, gdriv
 		return fmt.Errorf("テンプレートファイルのオープンに失敗： %w", err)
 	}
 	htmlFileName := fmt.Sprintf("%s.html", channelName)
-	htmlFilePath := path.Join(c.basedir, HtmlDir, htmlFileName)
+	htmlFilePath, err := c.safeJoinUnderBase(filepath.Join(HtmlDir, htmlFileName))
+	if err != nil {
+		return fmt.Errorf("invalid html file path: %w", err)
+	}
 	if err = os.MkdirAll(filepath.Dir(htmlFilePath), os.ModePerm); err != nil {
 		return fmt.Errorf("HTMLディレクトリの作成に失敗： %w", err)
 	}
@@ -140,6 +146,30 @@ func (c *Channels) CreateHtmlFile(ctx context.Context, channelName string, gdriv
 		return fmt.Errorf(" Google DriveへのHTMLファイルアップロードに失敗： %w", err)
 	}
 	return nil
+}
+
+func (c *Channels) safeJoinUnderBase(relPath string) (string, error) {
+	cleaned := filepath.Clean(relPath)
+	if filepath.IsAbs(cleaned) {
+		return "", fmt.Errorf("absolute path is not allowed: %s", relPath)
+	}
+
+	baseAbs, err := filepath.Abs(c.basedir)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve base directory: %w", err)
+	}
+	resolvedAbs, err := filepath.Abs(filepath.Join(baseAbs, cleaned))
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve target path: %w", err)
+	}
+	rel, err := filepath.Rel(baseAbs, resolvedAbs)
+	if err != nil {
+		return "", fmt.Errorf("failed to compare base and target path: %w", err)
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("path escapes base directory: %s", relPath)
+	}
+	return resolvedAbs, nil
 }
 
 func parseEntriesFromJSONL(r io.Reader) ([]Entry, error) {

--- a/client/channels_test.go
+++ b/client/channels_test.go
@@ -3,6 +3,7 @@ package client
 import (
 	"fmt"
 	"html/template"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -182,5 +183,33 @@ func TestParseEntriesFromJSONL_LongLine(t *testing.T) {
 	}
 	if entries[0].Message != longMessage {
 		t.Errorf("parseEntriesFromJSONL() message length = %d, want %d", len(entries[0].Message), len(longMessage))
+	}
+}
+
+func TestChannels_safeJoinUnderBase(t *testing.T) {
+	baseDir := t.TempDir()
+	c := &Channels{basedir: baseDir}
+
+	tests := []struct {
+		name    string
+		relPath string
+		wantErr bool
+	}{
+		{name: "jsonl file under base", relPath: "general.jsonl", wantErr: false},
+		{name: "html file under sub dir", relPath: filepath.Join("html", "general.html"), wantErr: false},
+		{name: "parent traversal", relPath: filepath.Join("..", "secret.txt"), wantErr: true},
+		{name: "absolute path", relPath: filepath.Join(baseDir, "outside.txt"), wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := c.safeJoinUnderBase(tt.relPath)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("safeJoinUnderBase() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err == nil && !strings.HasPrefix(got, baseDir) {
+				t.Fatalf("safeJoinUnderBase() path = %q, want prefix %q", got, baseDir)
+			}
+		})
 	}
 }

--- a/client/handlers.go
+++ b/client/handlers.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"regexp"
 	"strings"
 
 	"github.com/slack-go/slack"
@@ -14,6 +15,8 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 )
+
+var channelNamePattern = regexp.MustCompile(`^[a-z0-9_-]+$`)
 
 // MessageEventHandler チャンネルごとのメッセージ受信ハンドラー: MessageEventHandler はメッセージイベントを処理します。
 func MessageEventHandler(channels *Channels, botID string, gdrive *GDrive) socketmode.SocketmodeHandlerFunc {
@@ -234,9 +237,10 @@ func executeCommand(ctx context.Context, ev slack.SlashCommand, channels *Channe
 	var msg string
 	if strings.HasPrefix(ev.Command, "/make-html") {
 		msg = "Created html file"
-		channelName := ev.ChannelName
-		if len(ev.Text) > 0 {
-			channelName = strings.ReplaceAll(ev.Text, ".jsonl", "")
+		channelName := resolvedChannelName(ev)
+		if err := validateChannelName(channelName); err != nil {
+			msg = fmt.Sprintf("%v\nError: %v", msg, err.Error())
+			return msg
 		}
 		err := channels.CreateHtmlFile(ctx, channelName, gdrive)
 		if err != nil {
@@ -266,6 +270,24 @@ func executeCommand(ctx context.Context, ev slack.SlashCommand, channels *Channe
 		msg = "Unknown command..."
 	}
 	return msg
+}
+
+func resolvedChannelName(ev slack.SlashCommand) string {
+	channelName := strings.TrimSpace(ev.ChannelName)
+	if raw := strings.TrimSpace(ev.Text); raw != "" {
+		channelName = strings.TrimSpace(strings.TrimSuffix(raw, ".jsonl"))
+	}
+	return channelName
+}
+
+func validateChannelName(channelName string) error {
+	if channelName == "" {
+		return fmt.Errorf("invalid channel name: must not be empty")
+	}
+	if !channelNamePattern.MatchString(channelName) {
+		return fmt.Errorf("invalid channel name %q: allowed pattern is [a-z0-9_-]+", channelName)
+	}
+	return nil
 }
 
 func htmlFileNames(basedir string) map[string]bool {

--- a/client/handlers_test.go
+++ b/client/handlers_test.go
@@ -8,6 +8,73 @@ import (
 	"github.com/slack-go/slack/socketmode"
 )
 
+func TestResolvedChannelName(t *testing.T) {
+	tests := []struct {
+		name string
+		ev   slack.SlashCommand
+		want string
+	}{
+		{
+			name: "default channel name",
+			ev: slack.SlashCommand{
+				ChannelName: "general",
+			},
+			want: "general",
+		},
+		{
+			name: "text overrides with jsonl suffix",
+			ev: slack.SlashCommand{
+				ChannelName: "general",
+				Text:        "dev-team.jsonl",
+			},
+			want: "dev-team",
+		},
+		{
+			name: "text overrides with spaces",
+			ev: slack.SlashCommand{
+				ChannelName: "general",
+				Text:        "  team_1  ",
+			},
+			want: "team_1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := resolvedChannelName(tt.ev); got != tt.want {
+				t.Fatalf("resolvedChannelName() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateChannelName(t *testing.T) {
+	tests := []struct {
+		name        string
+		channelName string
+		wantErr     bool
+	}{
+		{name: "valid simple", channelName: "general", wantErr: false},
+		{name: "valid underscore", channelName: "team_1", wantErr: false},
+		{name: "valid hyphen", channelName: "dev-ops", wantErr: false},
+		{name: "invalid empty", channelName: "", wantErr: true},
+		{name: "invalid traversal", channelName: "../etc", wantErr: true},
+		{name: "invalid windows traversal", channelName: "..\\etc", wantErr: true},
+		{name: "invalid slash", channelName: "a/b", wantErr: true},
+		{name: "invalid absolute", channelName: "/tmp/test", wantErr: true},
+		{name: "invalid uppercase", channelName: "General", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateChannelName(tt.channelName)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("validateChannelName() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func TestSlashCommandFromEventData(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
## Summary
- Validate `/make-html` `channelName` with allowlist pattern `[a-z0-9_-]+`
- Normalize slash-command input (`trim` + optional `.jsonl` suffix removal)
- Add base directory boundary check using `filepath.Clean` + `filepath.Rel` in `CreateHtmlFile`
- Add tests for `channelName` validation and `base_dir` escape prevention

## Test
- `gofmt -w client/handlers.go client/channels.go client/handlers_test.go client/channels_test.go`
- `go test ./...`

## Acceptance Criteria Mapping
- Invalid `channelName` values like `../` are rejected before file operations
- Resolved paths cannot escape `base_dir`
- Valid `channelName` values continue to work