### PR TITLE
feat: add /make-md markdown+zip export MVP

### DIFF
--- a/client/channels.go
+++ b/client/channels.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"archive/zip"
 	"bufio"
 	"context"
 	"encoding/json"
@@ -22,6 +23,15 @@ type Channels struct {
 	basedir        string
 	authorID       string
 	previewFetcher linkPreviewFetchFunc
+}
+
+// MarkdownExportResult は /make-md で生成した成果物の情報です。
+type MarkdownExportResult struct {
+	ZipPath          string
+	EntryCount       int
+	AttachmentCount  int
+	AttachmentFailed int
+	Warnings         []string
 }
 
 const (
@@ -146,6 +156,211 @@ func (c *Channels) CreateHtmlFile(ctx context.Context, channelName string, gdriv
 		return fmt.Errorf(" Google DriveへのHTMLファイルアップロードに失敗： %w", err)
 	}
 	return nil
+}
+
+// CreateMarkdownZip はチャンネルのJSONLからMarkdownと添付ファイルZIPを生成します。
+func (c *Channels) CreateMarkdownZip(channelName string, authorID string, since *time.Time) (MarkdownExportResult, error) {
+	filePath, err := c.safeJoinUnderBase(c.createChannelFileName(channelName))
+	if err != nil {
+		return MarkdownExportResult{}, fmt.Errorf("invalid channel path: %w", err)
+	}
+
+	f, err := os.Open(filePath)
+	if err != nil {
+		return MarkdownExportResult{}, fmt.Errorf("ファイル %s のオープンに失敗： %w", filePath, err)
+	}
+	defer f.Close()
+
+	entries, err := parseEntriesFromJSONL(f)
+	if err != nil {
+		return MarkdownExportResult{}, err
+	}
+	filtered := filterEntriesSince(entries, since)
+
+	if err := os.MkdirAll(filepath.Join(c.basedir, "exports"), os.ModePerm); err != nil {
+		return MarkdownExportResult{}, fmt.Errorf("エクスポートディレクトリの作成に失敗: %w", err)
+	}
+	now := time.Now().UTC()
+	zipFilename := fmt.Sprintf("%s-%s.zip", channelName, now.Format("20060102-150405"))
+	zipPath := filepath.Join(c.basedir, "exports", zipFilename)
+	out, err := os.OpenFile(zipPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
+	if err != nil {
+		return MarkdownExportResult{}, fmt.Errorf("zipファイルの作成に失敗: %w", err)
+	}
+	defer out.Close()
+
+	zw := zip.NewWriter(out)
+	md, err := renderMarkdown(channelName, authorID, filtered, now, since)
+	if err != nil {
+		_ = zw.Close()
+		return MarkdownExportResult{}, err
+	}
+	indexWriter, err := zw.Create("index.md")
+	if err != nil {
+		_ = zw.Close()
+		return MarkdownExportResult{}, fmt.Errorf("index.md の作成に失敗: %w", err)
+	}
+	if _, err := indexWriter.Write([]byte(md)); err != nil {
+		_ = zw.Close()
+		return MarkdownExportResult{}, fmt.Errorf("index.md への書き込みに失敗: %w", err)
+	}
+
+	warnings, attachmentCount, attachmentFailed := c.addAttachmentsToZip(zw, filtered)
+	if err := zw.Close(); err != nil {
+		return MarkdownExportResult{}, fmt.Errorf("zipクローズに失敗: %w", err)
+	}
+
+	return MarkdownExportResult{
+		ZipPath:          zipPath,
+		EntryCount:       len(filtered),
+		AttachmentCount:  attachmentCount,
+		AttachmentFailed: attachmentFailed,
+		Warnings:         warnings,
+	}, nil
+}
+
+func filterEntriesSince(entries []Entry, since *time.Time) []Entry {
+	if since == nil {
+		return entries
+	}
+	filtered := make([]Entry, 0, len(entries))
+	for _, entry := range entries {
+		ts, ok := parseEntryTimestamp(entry.Timestamp)
+		if !ok {
+			continue
+		}
+		if ts.Before(*since) {
+			continue
+		}
+		filtered = append(filtered, entry)
+	}
+	return filtered
+}
+
+func parseEntryTimestamp(raw string) (time.Time, bool) {
+	splits := strings.Split(raw, ".")
+	if len(splits) < 1 {
+		return time.Time{}, false
+	}
+	sec, err := strconv.ParseInt(splits[0], 10, 64)
+	if err != nil {
+		return time.Time{}, false
+	}
+	nano := int64(0)
+	if len(splits) >= 2 {
+		fracStr := splits[1]
+		const nanoDigits = 9
+		if len(fracStr) < nanoDigits {
+			fracStr = fracStr + strings.Repeat("0", nanoDigits-len(fracStr))
+		} else if len(fracStr) > nanoDigits {
+			fracStr = fracStr[:nanoDigits]
+		}
+		nano, err = strconv.ParseInt(fracStr, 10, 64)
+		if err != nil {
+			return time.Time{}, false
+		}
+	}
+	return time.Unix(sec, nano).UTC(), true
+}
+
+func renderMarkdown(channelName string, authorID string, entries []Entry, generatedAt time.Time, since *time.Time) (string, error) {
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("# %s\n\n", channelName))
+	b.WriteString(fmt.Sprintf("- generated_at_utc: %s\n", generatedAt.Format(time.RFC3339)))
+	if since != nil {
+		b.WriteString(fmt.Sprintf("- since_utc: %s\n", since.Format(time.RFC3339)))
+	}
+	b.WriteString(fmt.Sprintf("- entries: %d\n\n", len(entries)))
+
+	for _, entry := range entries {
+		b.WriteString("## Entry\n\n")
+		b.WriteString(fmt.Sprintf("- datetime_utc: %s\n", entry.Timestamp2String()))
+		b.WriteString(fmt.Sprintf("- author: %s\n\n", authorID))
+		fence := markdownFenceFor(entry.Message)
+		b.WriteString(fence)
+		b.WriteString("\n")
+		b.WriteString(entry.Message)
+		if !strings.HasSuffix(entry.Message, "\n") {
+			b.WriteString("\n")
+		}
+		b.WriteString(fence)
+		b.WriteString("\n\n")
+	}
+
+	return b.String(), nil
+}
+
+func markdownFenceFor(message string) string {
+	maxTicks := 0
+	current := 0
+	for _, r := range message {
+		if r == '`' {
+			current++
+			if current > maxTicks {
+				maxTicks = current
+			}
+			continue
+		}
+		current = 0
+	}
+	if maxTicks < 3 {
+		return "```text"
+	}
+	return strings.Repeat("`", maxTicks+1) + "text"
+}
+
+func (c *Channels) addAttachmentsToZip(zw *zip.Writer, entries []Entry) ([]string, int, int) {
+	seen := make(map[string]bool)
+	warnings := make([]string, 0)
+	successCount := 0
+	failedCount := 0
+
+	for _, entry := range entries {
+		for _, rel := range entry.Files {
+			normalized := filepath.Clean(rel)
+			if filepath.IsAbs(normalized) || normalized == ".." || strings.HasPrefix(normalized, ".."+string(filepath.Separator)) {
+				warnings = append(warnings, fmt.Sprintf("skip invalid attachment path: %s", rel))
+				failedCount++
+				continue
+			}
+			if seen[normalized] {
+				continue
+			}
+			seen[normalized] = true
+
+			srcPath, err := c.safeJoinUnderBase(normalized)
+			if err != nil {
+				warnings = append(warnings, fmt.Sprintf("attachment path resolution failed: %s (%v)", rel, err))
+				failedCount++
+				continue
+			}
+			src, err := os.Open(srcPath)
+			if err != nil {
+				warnings = append(warnings, fmt.Sprintf("attachment open failed: %s (%v)", rel, err))
+				failedCount++
+				continue
+			}
+
+			archivePath := path.Join("attachments", filepath.ToSlash(normalized))
+			dst, err := zw.Create(archivePath)
+			if err != nil {
+				_ = src.Close()
+				warnings = append(warnings, fmt.Sprintf("attachment zip entry failed: %s (%v)", rel, err))
+				failedCount++
+				continue
+			}
+			if _, err := io.Copy(dst, src); err != nil {
+				_ = src.Close()
+				warnings = append(warnings, fmt.Sprintf("attachment copy failed: %s (%v)", rel, err))
+				failedCount++
+				continue
+			}
+			_ = src.Close()
+			successCount++
+		}
+	}
+
+	return warnings, successCount, failedCount
 }
 
 func (c *Channels) safeJoinUnderBase(relPath string) (string, error) {

--- a/client/channels_test.go
+++ b/client/channels_test.go
@@ -1,12 +1,15 @@
 package client
 
 import (
+	"archive/zip"
 	"fmt"
 	"html/template"
+	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestEntry_MessageWithLinkTag(t *testing.T) {
@@ -211,5 +214,107 @@ func TestChannels_safeJoinUnderBase(t *testing.T) {
 				t.Fatalf("safeJoinUnderBase() path = %q, want prefix %q", got, baseDir)
 			}
 		})
+	}
+}
+
+func TestFilterEntriesSince(t *testing.T) {
+	since := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+	entries := []Entry{
+		{Timestamp: "1711670400.000000"}, // 2024-03-29
+		{Timestamp: "1775001600.000000"}, // 2026-04-01
+		{Timestamp: "1775088000.000000"}, // 2026-04-02
+		{Timestamp: "invalid"},
+	}
+
+	got := filterEntriesSince(entries, &since)
+	if len(got) != 2 {
+		t.Fatalf("filterEntriesSince() len = %d, want 2", len(got))
+	}
+}
+
+func TestRenderMarkdown_PreserveNewlinesAndBackticks(t *testing.T) {
+	now := time.Date(2026, 4, 9, 12, 0, 0, 0, time.UTC)
+	entry := Entry{
+		Timestamp: "1775001600.123456",
+		Message:   "line1\n```go\nfmt.Println(\"x\")\n```\nline2",
+	}
+	md, err := renderMarkdown("general", "U123", []Entry{entry}, now, nil)
+	if err != nil {
+		t.Fatalf("renderMarkdown() error = %v", err)
+	}
+	if !strings.Contains(md, "line1\n```go\nfmt.Println(\"x\")\n```\nline2") {
+		t.Fatalf("renderMarkdown() message body not preserved: %s", md)
+	}
+	if !strings.Contains(md, "datetime_utc:") {
+		t.Fatalf("renderMarkdown() missing timestamp section")
+	}
+}
+
+func TestCreateMarkdownZip_IncludesIndexAndAttachments(t *testing.T) {
+	baseDir := t.TempDir()
+	c := &Channels{basedir: baseDir}
+
+	jsonl := `{"timestamp":"1775001600.123456","message":"hello","channel":{"id":"C1","name":"general"},"files":["images/general/a.png"]}` + "\n"
+	if err := os.WriteFile(filepath.Join(baseDir, "general.jsonl"), []byte(jsonl), 0644); err != nil {
+		t.Fatalf("write jsonl: %v", err)
+	}
+	imgPath := filepath.Join(baseDir, "images", "general", "a.png")
+	if err := os.MkdirAll(filepath.Dir(imgPath), os.ModePerm); err != nil {
+		t.Fatalf("mkdir image dir: %v", err)
+	}
+	if err := os.WriteFile(imgPath, []byte("png-data"), 0644); err != nil {
+		t.Fatalf("write image: %v", err)
+	}
+
+	result, err := c.CreateMarkdownZip("general", "U123", nil)
+	if err != nil {
+		t.Fatalf("CreateMarkdownZip() error = %v", err)
+	}
+	if result.EntryCount != 1 {
+		t.Fatalf("CreateMarkdownZip() EntryCount = %d, want 1", result.EntryCount)
+	}
+	if result.AttachmentCount != 1 {
+		t.Fatalf("CreateMarkdownZip() AttachmentCount = %d, want 1", result.AttachmentCount)
+	}
+
+	zr, err := zip.OpenReader(result.ZipPath)
+	if err != nil {
+		t.Fatalf("open zip: %v", err)
+	}
+	defer zr.Close()
+
+	entries := make(map[string]bool)
+	for _, f := range zr.File {
+		entries[f.Name] = true
+	}
+	if !entries["index.md"] {
+		t.Fatalf("zip missing index.md")
+	}
+	if !entries["attachments/images/general/a.png"] {
+		t.Fatalf("zip missing attachment entry")
+	}
+}
+
+func TestCreateMarkdownZip_MissingAttachmentContinues(t *testing.T) {
+	baseDir := t.TempDir()
+	c := &Channels{basedir: baseDir}
+
+	jsonl := `{"timestamp":"1775001600.123456","message":"hello","channel":{"id":"C1","name":"general"},"files":["images/general/missing.png"]}` + "\n"
+	if err := os.WriteFile(filepath.Join(baseDir, "general.jsonl"), []byte(jsonl), 0644); err != nil {
+		t.Fatalf("write jsonl: %v", err)
+	}
+
+	result, err := c.CreateMarkdownZip("general", "U123", nil)
+	if err != nil {
+		t.Fatalf("CreateMarkdownZip() error = %v", err)
+	}
+	if result.AttachmentCount != 0 {
+		t.Fatalf("CreateMarkdownZip() AttachmentCount = %d, want 0", result.AttachmentCount)
+	}
+	if result.AttachmentFailed == 0 {
+		t.Fatalf("CreateMarkdownZip() AttachmentFailed = 0, want > 0")
+	}
+	if len(result.Warnings) == 0 {
+		t.Fatalf("CreateMarkdownZip() Warnings empty, want warning")
 	}
 }

--- a/client/handlers.go
+++ b/client/handlers.go
@@ -4,10 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"os"
 	"path"
+	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/slack-go/slack"
 	"github.com/slack-go/slack/slackevents"
@@ -216,7 +220,7 @@ func SlashCommandHandler(channels *Channels, gdrive *GDrive, basedir string) soc
 			return
 		}
 
-		msg := executeCommand(ctx, ev, channels, gdrive, basedir)
+		msg := executeCommand(ctx, ev, channels, gdrive, basedir, client)
 
 		if _, _, err := client.PostMessage(ev.ChannelID, slack.MsgOptionText(msg, false)); err != nil {
 			fmt.Printf("######### : failed posting message: %v\n", err)
@@ -230,7 +234,7 @@ func slashCommandFromEventData(data interface{}) (slack.SlashCommand, bool) {
 	return ev, ok
 }
 
-func executeCommand(ctx context.Context, ev slack.SlashCommand, channels *Channels, gdrive *GDrive, basedir string) string {
+func executeCommand(ctx context.Context, ev slack.SlashCommand, channels *Channels, gdrive *GDrive, basedir string, client *socketmode.Client) string {
 	ctx, span := tracer.Start(ctx, "executeCommand")
 	defer span.End()
 
@@ -266,6 +270,42 @@ func executeCommand(ctx context.Context, ev slack.SlashCommand, channels *Channe
 			}
 		}
 		msg = fmt.Sprintf("%s\n%s\n", msg, strings.Join(files, "\n"))
+	} else if strings.HasPrefix(ev.Command, "/make-md") {
+		msg = "Created markdown zip file"
+		channelName, since, err := resolveMakeMDParams(ev)
+		if err != nil {
+			return fmt.Sprintf("%v\nError: %v", msg, err.Error())
+		}
+		if err := validateChannelName(channelName); err != nil {
+			return fmt.Sprintf("%v\nError: %v", msg, err.Error())
+		}
+
+		result, err := channels.CreateMarkdownZip(channelName, channels.authorID, since)
+		if err != nil {
+			fmt.Printf("######### : Got error %v\n", err)
+			return fmt.Sprintf("%v\nError: %v", msg, err.Error())
+		}
+		for _, warning := range result.Warnings {
+			log.Printf("[make-md] %s", warning)
+		}
+
+		if client != nil {
+			filename := filepath.Base(result.ZipPath)
+			uploadMsg := fmt.Sprintf("%d entries, %d attachments", result.EntryCount, result.AttachmentCount)
+			if _, err := client.UploadFileV2(slack.UploadFileV2Parameters{
+				Channel:        ev.ChannelID,
+				File:           result.ZipPath,
+				Filename:       filename,
+				Title:          filename,
+				InitialComment: uploadMsg,
+			}); err != nil {
+				fmt.Printf("######### : failed to upload markdown zip: %v\n", err)
+				return fmt.Sprintf("%v\nError: failed to upload zip: %v", msg, err)
+			}
+			msg = fmt.Sprintf("%s\nUploaded: %s (%s)", msg, filename, uploadMsg)
+		} else {
+			msg = fmt.Sprintf("%s\nSaved to: %s", msg, result.ZipPath)
+		}
 	} else {
 		msg = "Unknown command..."
 	}
@@ -288,6 +328,55 @@ func validateChannelName(channelName string) error {
 		return fmt.Errorf("invalid channel name %q: allowed pattern is [a-z0-9_-]+", channelName)
 	}
 	return nil
+}
+
+func resolveMakeMDParams(ev slack.SlashCommand) (string, *time.Time, error) {
+	channelName := strings.TrimSpace(ev.ChannelName)
+	args := strings.Fields(strings.TrimSpace(ev.Text))
+	if len(args) == 0 {
+		return channelName, nil, nil
+	}
+	if len(args) > 2 {
+		return "", nil, fmt.Errorf("invalid args: expected /make-md [channel] [period] or /make-md [period]")
+	}
+
+	if len(args) == 1 {
+		if since, ok, err := parseRelativePeriod(args[0]); err != nil {
+			return "", nil, err
+		} else if ok {
+			return channelName, since, nil
+		}
+		return strings.TrimSpace(strings.TrimSuffix(args[0], ".jsonl")), nil, nil
+	}
+
+	since, ok, err := parseRelativePeriod(args[1])
+	if err != nil {
+		return "", nil, err
+	}
+	if !ok {
+		return "", nil, fmt.Errorf("invalid period: %q (e.g. 30d)", args[1])
+	}
+	return strings.TrimSpace(strings.TrimSuffix(args[0], ".jsonl")), since, nil
+}
+
+func parseRelativePeriod(raw string) (*time.Time, bool, error) {
+	period := strings.TrimSpace(strings.ToLower(raw))
+	if period == "" {
+		return nil, false, nil
+	}
+	matches := regexp.MustCompile(`^(\d+)d$`).FindStringSubmatch(period)
+	if len(matches) != 2 {
+		return nil, false, nil
+	}
+	days, err := strconv.Atoi(matches[1])
+	if err != nil {
+		return nil, true, fmt.Errorf("invalid period: %q", raw)
+	}
+	if days <= 0 {
+		return nil, true, fmt.Errorf("invalid period: %q (days must be > 0)", raw)
+	}
+	since := time.Now().UTC().AddDate(0, 0, -days)
+	return &since, true, nil
 }
 
 func htmlFileNames(basedir string) map[string]bool {

--- a/client/handlers_test.go
+++ b/client/handlers_test.go
@@ -1,7 +1,9 @@
 package client
 
 import (
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/slack-go/slack"
 	"github.com/slack-go/slack/slackevents"
@@ -116,6 +118,126 @@ func TestSlashCommandFromEventData(t *testing.T) {
 	}
 }
 
+func TestResolveMakeMDParams(t *testing.T) {
+	tests := []struct {
+		name        string
+		ev          slack.SlashCommand
+		wantChannel string
+		wantSince   bool
+		wantErr     bool
+	}{
+		{
+			name: "no args uses current channel",
+			ev: slack.SlashCommand{
+				ChannelName: "general",
+			},
+			wantChannel: "general",
+			wantSince:   false,
+			wantErr:     false,
+		},
+		{
+			name: "single period arg",
+			ev: slack.SlashCommand{
+				ChannelName: "general",
+				Text:        "30d",
+			},
+			wantChannel: "general",
+			wantSince:   true,
+			wantErr:     false,
+		},
+		{
+			name: "single channel arg",
+			ev: slack.SlashCommand{
+				ChannelName: "general",
+				Text:        "dev-team.jsonl",
+			},
+			wantChannel: "dev-team",
+			wantSince:   false,
+			wantErr:     false,
+		},
+		{
+			name: "channel and period",
+			ev: slack.SlashCommand{
+				ChannelName: "general",
+				Text:        "dev-team 7d",
+			},
+			wantChannel: "dev-team",
+			wantSince:   true,
+			wantErr:     false,
+		},
+		{
+			name: "too many args",
+			ev: slack.SlashCommand{
+				ChannelName: "general",
+				Text:        "a b c",
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid second arg",
+			ev: slack.SlashCommand{
+				ChannelName: "general",
+				Text:        "dev-team 12h",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ch, since, err := resolveMakeMDParams(tt.ev)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("resolveMakeMDParams() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if ch != tt.wantChannel {
+				t.Fatalf("resolveMakeMDParams() channel = %q, want %q", ch, tt.wantChannel)
+			}
+			if (since != nil) != tt.wantSince {
+				t.Fatalf("resolveMakeMDParams() since nil=%v, wantSince %v", since == nil, tt.wantSince)
+			}
+		})
+	}
+}
+
+func TestParseRelativePeriod(t *testing.T) {
+	tests := []struct {
+		name      string
+		raw       string
+		wantFound bool
+		wantErr   bool
+	}{
+		{name: "valid", raw: "30d", wantFound: true, wantErr: false},
+		{name: "valid upper", raw: "7D", wantFound: true, wantErr: false},
+		{name: "empty", raw: "", wantFound: false, wantErr: false},
+		{name: "wrong suffix", raw: "30h", wantFound: false, wantErr: false},
+		{name: "zero day", raw: "0d", wantFound: true, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			since, found, err := parseRelativePeriod(tt.raw)
+			if found != tt.wantFound {
+				t.Fatalf("parseRelativePeriod() found = %v, want %v", found, tt.wantFound)
+			}
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("parseRelativePeriod() err = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantFound && !tt.wantErr {
+				if since == nil {
+					t.Fatalf("parseRelativePeriod() since is nil")
+				}
+				diff := time.Since(*since)
+				if diff < 0 || diff > 31*24*time.Hour {
+					t.Fatalf("parseRelativePeriod() unexpected since: %v", *since)
+				}
+			}
+		})
+	}
+}
+
 func TestSkipMessage(t *testing.T) {
 	botMention := "<@B999>"
 	channels := &Channels{authorID: "U123"}
@@ -185,5 +307,31 @@ func TestSkipMessage(t *testing.T) {
 				t.Fatalf("skipMessage() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestParseRelativePeriodPatternOnlyD(t *testing.T) {
+	_, found, err := parseRelativePeriod("15w")
+	if err != nil {
+		t.Fatalf("parseRelativePeriod() unexpected err: %v", err)
+	}
+	if found {
+		t.Fatalf("parseRelativePeriod() found = true, want false")
+	}
+
+	_, found, err = parseRelativePeriod(" 15d ")
+	if err != nil {
+		t.Fatalf("parseRelativePeriod() unexpected err: %v", err)
+	}
+	if !found {
+		t.Fatalf("parseRelativePeriod() found = false, want true")
+	}
+
+	_, found, err = parseRelativePeriod(strings.Repeat("1", 100) + "d")
+	if !found {
+		t.Fatalf("parseRelativePeriod() found = false, want true")
+	}
+	if err == nil {
+		t.Fatalf("parseRelativePeriod() err = nil, want error for overflow")
 	}
 }


### PR DESCRIPTION
## Summary
- add `/make-md` slash command handling
- support args parsing for `/make-md [channel] [period]` and `/make-md [period]` (`Nd` format like `30d`)
- generate export ZIP with `index.md` + available attachments under `attachments/...`
- continue export on partial attachment failures and log warnings
- upload generated ZIP to Slack channel via `UploadFileV2`
- add tests for args parsing, period parsing, markdown rendering, zip export, and partial attachment failure behavior

## Scope notes (Issue #74 MVP)
- includes Markdown + attachment ZIP export flow
- excludes Google Drive upload for generated artifacts

## Verification
- `gofmt -w client/handlers.go client/channels.go client/handlers_test.go client/channels_test.go`
- `go test ./...`

Closes #74
