### PR TITLE
Fix #71: preserve successful attachments on partial download failure

### DIFF
--- a/client/gdrive.go
+++ b/client/gdrive.go
@@ -13,14 +13,15 @@ import (
 )
 
 type GDrive struct {
-	client          *drive.Service
-	baseDir         string
-	targetDir       *drive.File
-	imageDir        *drive.File
-	htmlDir         *drive.File
-	getTargetFileFn func(ctx context.Context, filename, dirid string) *drive.File
-	createFileFn    func(ctx context.Context, name, parent, filepath string) error
-	updateFileFn    func(ctx context.Context, name, id, filepath string) error
+	client            *drive.Service
+	baseDir           string
+	targetDir         *drive.File
+	imageDir          *drive.File
+	htmlDir           *drive.File
+	getTargetFileFn   func(ctx context.Context, filename, dirid string) *drive.File
+	createImageFileFn func(ctx context.Context, name, parent, filepath string) error
+	createFileFn      func(ctx context.Context, name, parent, filepath string) error
+	updateFileFn      func(ctx context.Context, name, id, filepath string) error
 }
 
 func (g GDrive) htmlCreateParentID() string {
@@ -201,6 +202,10 @@ func (g GDrive) createDir(ctx context.Context, name string, parentId string) (*d
 
 // CreateImageFile 画像ファイルをimageDirにアップロードする
 func (g GDrive) CreateImageFile(ctx context.Context, name string, parent string, filepath string) error {
+	if g.createImageFileFn != nil {
+		return g.createImageFileFn(ctx, name, parent, filepath)
+	}
+
 	if g.imageDir == nil {
 		return fmt.Errorf("imageDir が初期化されていません。Google Drive上に images フォルダが存在するか確認してください")
 	}

--- a/client/handlers.go
+++ b/client/handlers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"path"
@@ -21,6 +22,10 @@ import (
 )
 
 var channelNamePattern = regexp.MustCompile(`^[a-z0-9_-]+$`)
+
+type fileContextGetter interface {
+	GetFileContext(ctx context.Context, downloadURL string, writer io.Writer) error
+}
 
 // MessageEventHandler チャンネルごとのメッセージ受信ハンドラー: MessageEventHandler はメッセージイベントを処理します。
 func MessageEventHandler(channels *Channels, botID string, gdrive *GDrive) socketmode.SocketmodeHandlerFunc {
@@ -82,9 +87,8 @@ func MessageEventHandler(channels *Channels, botID string, gdrive *GDrive) socke
 			files, err := downloadImageFiles(ctx, client, channel.Name, channels, p.Message.Files, p.EventTimeStamp, gdrive)
 			if err != nil {
 				client.Debugf("ファイルダウンロードエラー: %v", err)
-			} else {
-				data.Files = files
 			}
+			data.Files = files
 
 		}
 
@@ -123,7 +127,7 @@ func skipMessage(p *slackevents.MessageEvent, botMention string, client *socketm
 	return false
 }
 
-func downloadImageFiles(ctx context.Context, client *socketmode.Client, channelName string, channels *Channels, files []slack.File, timestamp string, gdrive *GDrive) ([]string, error) {
+func downloadImageFiles(ctx context.Context, client fileContextGetter, channelName string, channels *Channels, files []slack.File, timestamp string, gdrive *GDrive) ([]string, error) {
 	ctx, span := tracer.Start(ctx, "downloadImageFiles")
 	defer span.End()
 
@@ -131,30 +135,12 @@ func downloadImageFiles(ctx context.Context, client *socketmode.Client, channelN
 	errors := make([]string, 0)
 	for i, file := range files {
 		if len(file.URLPrivateDownload) > 0 {
-			localFile, err := channels.CreateLocalFile(channelName, timestamp, i, file.Filetype)
+			filename, err := downloadSingleImageFile(ctx, client, channelName, channels, file, timestamp, i, gdrive)
 			if err != nil {
 				errors = append(errors, err.Error())
-			} else {
-				err = client.GetFileContext(ctx, file.URLPrivateDownload, localFile)
-				localFile.Close()
-				if err != nil {
-					errors = append(errors, err.Error())
-				}
-				filenames = append(filenames, channels.CreateFilePathForMessage(
-					channelName,
-					timestamp,
-					i,
-					file.Filetype))
-				err = gdrive.CreateImageFile(ctx, channels.CreateImageFileName(timestamp, i, file.Filetype), channelName,
-					channels.CreateImageFilePath(
-						channelName,
-						timestamp,
-						i,
-						file.Filetype))
-				if err != nil {
-					errors = append(errors, err.Error())
-				}
+				continue
 			}
+			filenames = append(filenames, filename)
 		}
 	}
 	if len(errors) > 0 {
@@ -163,6 +149,29 @@ func downloadImageFiles(ctx context.Context, client *socketmode.Client, channelN
 	}
 
 	return filenames, nil
+}
+
+func downloadSingleImageFile(ctx context.Context, client fileContextGetter, channelName string, channels *Channels, file slack.File, timestamp string, index int, gdrive *GDrive) (string, error) {
+	localFile, err := channels.CreateLocalFile(channelName, timestamp, index, file.Filetype)
+	if err != nil {
+		return "", fmt.Errorf("attachment index=%d stage=create_local_file: %w", index, err)
+	}
+	defer localFile.Close()
+
+	if err := client.GetFileContext(ctx, file.URLPrivateDownload, localFile); err != nil {
+		return "", fmt.Errorf("attachment index=%d stage=download url=%s: %w", index, file.URLPrivateDownload, err)
+	}
+
+	if err := gdrive.CreateImageFile(
+		ctx,
+		channels.CreateImageFileName(timestamp, index, file.Filetype),
+		channelName,
+		channels.CreateImageFilePath(channelName, timestamp, index, file.Filetype),
+	); err != nil {
+		return "", fmt.Errorf("attachment index=%d stage=upload: %w", index, err)
+	}
+
+	return channels.CreateFilePathForMessage(channelName, timestamp, index, file.Filetype), nil
 }
 
 func BotJoinedEventHandler(botID string) socketmode.SocketmodeHandlerFunc {

--- a/client/handlers_test.go
+++ b/client/handlers_test.go
@@ -1,6 +1,9 @@
 package client
 
 import (
+	"context"
+	"errors"
+	"io"
 	"strings"
 	"testing"
 	"time"
@@ -9,6 +12,20 @@ import (
 	"github.com/slack-go/slack/slackevents"
 	"github.com/slack-go/slack/socketmode"
 )
+
+type stubFileContextGetter struct {
+	failByURL map[string]error
+}
+
+func (s stubFileContextGetter) GetFileContext(_ context.Context, downloadURL string, writer io.Writer) error {
+	if err, ok := s.failByURL[downloadURL]; ok {
+		return err
+	}
+	if _, err := io.WriteString(writer, "ok"); err != nil {
+		return err
+	}
+	return nil
+}
 
 func TestResolvedChannelName(t *testing.T) {
 	tests := []struct {
@@ -441,5 +458,101 @@ func TestParseRelativePeriodPatternOnlyD(t *testing.T) {
 	}
 	if err == nil {
 		t.Fatalf("parseRelativePeriod() err = nil, want error for overflow")
+	}
+}
+
+func TestDownloadImageFiles_AllSuccess(t *testing.T) {
+	channels := &Channels{basedir: t.TempDir()}
+	getter := stubFileContextGetter{}
+	uploadCalls := 0
+	gdrive := &GDrive{
+		createImageFileFn: func(ctx context.Context, name, parent, filepath string) error {
+			uploadCalls++
+			return nil
+		},
+	}
+	files := []slack.File{
+		{URLPrivateDownload: "https://example.com/1", Filetype: "png"},
+		{URLPrivateDownload: "https://example.com/2", Filetype: "jpg"},
+	}
+
+	got, err := downloadImageFiles(context.Background(), getter, "general", channels, files, "1711670400.000000", gdrive)
+	if err != nil {
+		t.Fatalf("downloadImageFiles() error = %v, want nil", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("downloadImageFiles() len = %d, want 2", len(got))
+	}
+	if uploadCalls != 2 {
+		t.Fatalf("upload calls = %d, want 2", uploadCalls)
+	}
+}
+
+func TestDownloadImageFiles_PartialFailureKeepsSuccesses(t *testing.T) {
+	channels := &Channels{basedir: t.TempDir()}
+	getter := stubFileContextGetter{
+		failByURL: map[string]error{
+			"https://example.com/2": errors.New("download failed"),
+		},
+	}
+	uploadCalls := 0
+	gdrive := &GDrive{
+		createImageFileFn: func(ctx context.Context, name, parent, filepath string) error {
+			uploadCalls++
+			return nil
+		},
+	}
+	files := []slack.File{
+		{URLPrivateDownload: "https://example.com/1", Filetype: "png"},
+		{URLPrivateDownload: "https://example.com/2", Filetype: "jpg"},
+	}
+
+	got, err := downloadImageFiles(context.Background(), getter, "general", channels, files, "1711670400.000000", gdrive)
+	if err == nil {
+		t.Fatal("downloadImageFiles() error = nil, want non-nil")
+	}
+	if len(got) != 1 {
+		t.Fatalf("downloadImageFiles() len = %d, want 1", len(got))
+	}
+	if uploadCalls != 1 {
+		t.Fatalf("upload calls = %d, want 1", uploadCalls)
+	}
+	if !strings.Contains(err.Error(), "index=1") || !strings.Contains(err.Error(), "stage=download") {
+		t.Fatalf("downloadImageFiles() error = %q, want index/stage info", err.Error())
+	}
+}
+
+func TestDownloadImageFiles_AllFailure(t *testing.T) {
+	channels := &Channels{basedir: t.TempDir()}
+	getter := stubFileContextGetter{
+		failByURL: map[string]error{
+			"https://example.com/1": errors.New("download failed 1"),
+			"https://example.com/2": errors.New("download failed 2"),
+		},
+	}
+	uploadCalls := 0
+	gdrive := &GDrive{
+		createImageFileFn: func(ctx context.Context, name, parent, filepath string) error {
+			uploadCalls++
+			return nil
+		},
+	}
+	files := []slack.File{
+		{URLPrivateDownload: "https://example.com/1", Filetype: "png"},
+		{URLPrivateDownload: "https://example.com/2", Filetype: "jpg"},
+	}
+
+	got, err := downloadImageFiles(context.Background(), getter, "general", channels, files, "1711670400.000000", gdrive)
+	if err == nil {
+		t.Fatal("downloadImageFiles() error = nil, want non-nil")
+	}
+	if len(got) != 0 {
+		t.Fatalf("downloadImageFiles() len = %d, want 0", len(got))
+	}
+	if uploadCalls != 0 {
+		t.Fatalf("upload calls = %d, want 0", uploadCalls)
+	}
+	if !strings.Contains(err.Error(), "index=0") || !strings.Contains(err.Error(), "index=1") {
+		t.Fatalf("downloadImageFiles() error = %q, want both failed indexes", err.Error())
 	}
 }


### PR DESCRIPTION
## Summary
- keep successful attachment paths in `data.Files` even when some downloads fail
- process each attachment independently and append filename only after successful download+upload
- add structured error context (`index`, `stage`, `url`) for failed attachments
- add tests for all-success / partial-failure / all-failure cases

## Testing
- go test ./...

Closes #71
