### PR TITLE
Issue #72: Google Drive検索エラーを上位へ伝播

### DIFF
--- a/client/bot.go
+++ b/client/bot.go
@@ -95,7 +95,9 @@ func loadConfigFromFile(configPath string) (Config, error) {
 	if err != nil {
 		return Config{}, err
 	}
-	defer file.Close()
+	defer func() {
+		_ = file.Close()
+	}()
 
 	// JSONデコード
 	decoder := json.NewDecoder(file)
@@ -144,12 +146,16 @@ func initHtml(config Config) error {
 		if err != nil {
 			return fmt.Errorf("CSS %s のオープンに失敗： %v", CSSFile, err)
 		}
-		defer src.Close()
+		defer func() {
+			_ = src.Close()
+		}()
 		dst, err := os.Create(path.Join(config.BaseDir, HtmlDir, CSSFile))
 		if err != nil {
 			return fmt.Errorf("CSS %s の作成に失敗： %v", CSSFile, err)
 		}
-		defer dst.Close()
+		defer func() {
+			_ = dst.Close()
+		}()
 		_, err = io.Copy(dst, src)
 		if err != nil {
 			return fmt.Errorf("CSS %s へのコピーに失敗： %v", CSSFile, err)

--- a/client/channels.go
+++ b/client/channels.go
@@ -66,8 +66,10 @@ func (c *Channels) AppendMessage(ctx context.Context, channelName, jsonstring st
 	if err != nil {
 		return fmt.Errorf("ファイル %s のオープンに失敗： %w", filePath, err)
 	}
-	defer f.Close()
-	if _, err := f.WriteString(fmt.Sprintf("%v\n", jsonstring)); err != nil {
+	defer func() {
+		_ = f.Close()
+	}()
+	if _, err := fmt.Fprintf(f, "%s\n", jsonstring); err != nil {
 		return fmt.Errorf("ファイル %s のオープンに失敗： %w", filePath, err)
 	}
 	return gdrive.UploadFile(ctx, channelFileName, filePath)
@@ -126,7 +128,9 @@ func (c *Channels) CreateHtmlFile(ctx context.Context, channelName string, gdriv
 	if err != nil {
 		return fmt.Errorf("ファイル %s のオープンに失敗： %w", filePath, err)
 	}
-	defer f.Close()
+	defer func() {
+		_ = f.Close()
+	}()
 	contents, err := parseEntriesFromJSONL(f)
 	if err != nil {
 		return err
@@ -155,7 +159,9 @@ func (c *Channels) CreateHtmlFile(ctx context.Context, channelName string, gdriv
 	if err != nil {
 		return fmt.Errorf("HTMLファイルのオープンに失敗： %w", err)
 	}
-	defer out.Close()
+	defer func() {
+		_ = out.Close()
+	}()
 	if err := t.Execute(out, values); err != nil {
 		return fmt.Errorf("テンプレートのExecuteに失敗： %w", err)
 	}
@@ -177,7 +183,9 @@ func (c *Channels) CreateMarkdownZip(channelName string, authorID string, since 
 	if err != nil {
 		return MarkdownExportResult{}, fmt.Errorf("ファイル %s のオープンに失敗： %w", filePath, err)
 	}
-	defer f.Close()
+	defer func() {
+		_ = f.Close()
+	}()
 
 	entries, err := parseEntriesFromJSONL(f)
 	if err != nil {
@@ -195,7 +203,9 @@ func (c *Channels) CreateMarkdownZip(channelName string, authorID string, since 
 	if err != nil {
 		return MarkdownExportResult{}, fmt.Errorf("zipファイルの作成に失敗: %w", err)
 	}
-	defer out.Close()
+	defer func() {
+		_ = out.Close()
+	}()
 
 	zw := zip.NewWriter(out)
 	md, err := renderMarkdown(channelName, authorID, filtered, now, since)
@@ -273,17 +283,17 @@ func parseEntryTimestamp(raw string) (time.Time, bool) {
 
 func renderMarkdown(channelName string, authorID string, entries []Entry, generatedAt time.Time, since *time.Time) (string, error) {
 	var b strings.Builder
-	b.WriteString(fmt.Sprintf("# %s\n\n", channelName))
-	b.WriteString(fmt.Sprintf("- generated_at_utc: %s\n", generatedAt.Format(time.RFC3339)))
+	_, _ = fmt.Fprintf(&b, "# %s\n\n", channelName)
+	_, _ = fmt.Fprintf(&b, "- generated_at_utc: %s\n", generatedAt.Format(time.RFC3339))
 	if since != nil {
-		b.WriteString(fmt.Sprintf("- since_utc: %s\n", since.Format(time.RFC3339)))
+		_, _ = fmt.Fprintf(&b, "- since_utc: %s\n", since.Format(time.RFC3339))
 	}
-	b.WriteString(fmt.Sprintf("- entries: %d\n\n", len(entries)))
+	_, _ = fmt.Fprintf(&b, "- entries: %d\n\n", len(entries))
 
 	for _, entry := range entries {
 		b.WriteString("## Entry\n\n")
-		b.WriteString(fmt.Sprintf("- datetime_utc: %s\n", entry.Timestamp2String()))
-		b.WriteString(fmt.Sprintf("- author: %s\n\n", authorID))
+		_, _ = fmt.Fprintf(&b, "- datetime_utc: %s\n", entry.Timestamp2String())
+		_, _ = fmt.Fprintf(&b, "- author: %s\n\n", authorID)
 		fence := markdownFenceFor(entry.Message)
 		b.WriteString(fence)
 		b.WriteString("\n")

--- a/client/channels_test.go
+++ b/client/channels_test.go
@@ -285,7 +285,9 @@ func TestCreateMarkdownZip_IncludesIndexAndAttachments(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open zip: %v", err)
 	}
-	defer zr.Close()
+	defer func() {
+		_ = zr.Close()
+	}()
 
 	entries := make(map[string]bool)
 	for _, f := range zr.File {
@@ -338,8 +340,8 @@ func TestCreateHtmlFile_WithSinceFiltersEntries(t *testing.T) {
 
 	g := &GDrive{
 		htmlDir: &drive.File{Id: "html-dir-id"},
-		getTargetFileFn: func(ctx context.Context, filename, dirid string) *drive.File {
-			return nil
+		getTargetFileFn: func(ctx context.Context, filename, dirid string) (*drive.File, error) {
+			return nil, nil
 		},
 		createFileFn: func(ctx context.Context, name, parent, filePath string) error {
 			return nil

--- a/client/gdrive.go
+++ b/client/gdrive.go
@@ -18,7 +18,7 @@ type GDrive struct {
 	targetDir         *drive.File
 	imageDir          *drive.File
 	htmlDir           *drive.File
-	getTargetFileFn   func(ctx context.Context, filename, dirid string) *drive.File
+	getTargetFileFn   func(ctx context.Context, filename, dirid string) (*drive.File, error)
 	createImageFileFn func(ctx context.Context, name, parent, filepath string) error
 	createFileFn      func(ctx context.Context, name, parent, filepath string) error
 	updateFileFn      func(ctx context.Context, name, id, filepath string) error
@@ -57,7 +57,10 @@ func NewGDrive(basedir string, credentialsJSON string, credentialsFilePath strin
 	ctx := context.Background()
 
 	// happeninghound フォルダを取得、なければ作成
-	targetDir := getTargetDir(ctx, "happeninghound", client)
+	targetDir, err := getTargetDir(ctx, "happeninghound", client)
+	if err != nil {
+		return nil, fmt.Errorf("happeninghound フォルダ検索に失敗: %w", err)
+	}
 	if targetDir == nil {
 		targetDir, err = createFolder(ctx, "happeninghound", "", client)
 		if err != nil {
@@ -66,7 +69,10 @@ func NewGDrive(basedir string, credentialsJSON string, credentialsFilePath strin
 	}
 
 	// images フォルダを取得、なければ作成
-	imageDir := getTargetDirWithParent(ctx, "images", targetDir.Id, client)
+	imageDir, err := getTargetDirWithParent(ctx, "images", targetDir.Id, client)
+	if err != nil {
+		return nil, fmt.Errorf("images フォルダ検索に失敗: %w", err)
+	}
 	if imageDir == nil {
 		imageDir, err = createFolder(ctx, "images", targetDir.Id, client)
 		if err != nil {
@@ -75,7 +81,10 @@ func NewGDrive(basedir string, credentialsJSON string, credentialsFilePath strin
 	}
 
 	// html フォルダを取得、なければ作成
-	htmlDir := getTargetDirWithParent(ctx, "html", targetDir.Id, client)
+	htmlDir, err := getTargetDirWithParent(ctx, "html", targetDir.Id, client)
+	if err != nil {
+		return nil, fmt.Errorf("html フォルダ検索に失敗: %w", err)
+	}
 	if htmlDir == nil {
 		htmlDir, err = createFolder(ctx, "html", targetDir.Id, client)
 		if err != nil {
@@ -92,37 +101,33 @@ func NewGDrive(basedir string, credentialsJSON string, credentialsFilePath strin
 	}, nil
 }
 
-func getTargetDir(ctx context.Context, dir string, client *drive.Service) *drive.File {
+func getTargetDir(ctx context.Context, dir string, client *drive.Service) (*drive.File, error) {
 	r, err := client.Files.List().Q(
 		fmt.Sprintf("name = '%s' and mimeType = 'application/vnd.google-apps.folder'", dir)).
 		PageSize(1).Fields("nextPageToken, files(id,name)").Context(ctx).Do()
 	if err != nil {
-		fmt.Print("Error in GetTargetDir")
-		fmt.Println(err)
-		return nil
+		return nil, fmt.Errorf("GetTargetDir APIエラー: %w", err)
 	}
 	if len(r.Files) > 0 {
 		f := r.Files[0]
-		return f
+		return f, nil
 	} else {
-		return nil
+		return nil, nil
 	}
 }
 
-func getTargetDirWithParent(ctx context.Context, dir, parentId string, client *drive.Service) *drive.File {
+func getTargetDirWithParent(ctx context.Context, dir, parentId string, client *drive.Service) (*drive.File, error) {
 	r, err := client.Files.List().Q(
 		fmt.Sprintf("name = '%s' and '%s' in parents and mimeType = 'application/vnd.google-apps.folder'", dir, parentId)).
 		PageSize(1).Fields("nextPageToken, files(id,name)").Context(ctx).Do()
 	if err != nil {
-		fmt.Println("Error in GetTargetDirWithParent")
-		fmt.Println(err)
-		return nil
+		return nil, fmt.Errorf("GetTargetDirWithParent APIエラー: %w", err)
 	}
 	if len(r.Files) > 0 {
 		f := r.Files[0]
-		return f
+		return f, nil
 	} else {
-		return nil
+		return nil, nil
 	}
 }
 
@@ -139,20 +144,18 @@ func createFolder(ctx context.Context, name, parentId string, client *drive.Serv
 	return dir, nil
 }
 
-func (g GDrive) getTargetFile(ctx context.Context, filename, dirid string) *drive.File {
+func (g GDrive) getTargetFile(ctx context.Context, filename, dirid string) (*drive.File, error) {
 	r, err := g.client.Files.List().Q(
 		fmt.Sprintf("name = '%s' and '%s' in parents", filename, dirid)).
 		PageSize(1).Fields("nextPageToken, files(id,name)").Context(ctx).Do()
 	if err != nil {
-		fmt.Print("Error in GetTargetFile")
-		fmt.Println(err)
-		return nil
+		return nil, fmt.Errorf("GetTargetFile APIエラー: %w", err)
 	}
 	if len(r.Files) > 0 {
 		f := r.Files[0]
-		return f
+		return f, nil
 	} else {
-		return nil
+		return nil, nil
 	}
 }
 
@@ -161,7 +164,9 @@ func (g GDrive) createFile(ctx context.Context, name string, parent string, file
 	if err != nil {
 		return err
 	}
-	defer local.Close()
+	defer func() {
+		_ = local.Close()
+	}()
 	driveFile, err := g.client.Files.Create(&drive.File{Name: name, Parents: []string{parent}}).Media(local).Context(ctx).Do()
 	if err != nil {
 		return err
@@ -175,7 +180,9 @@ func (g GDrive) updateFile(ctx context.Context, name, id string, filepath string
 	if err != nil {
 		return err
 	}
-	defer local.Close()
+	defer func() {
+		_ = local.Close()
+	}()
 	driveFile, err := g.client.Files.Update(id, &drive.File{Name: name}).Media(local).Context(ctx).Do()
 	if err != nil {
 		return err
@@ -186,9 +193,11 @@ func (g GDrive) updateFile(ctx context.Context, name, id string, filepath string
 
 // ディレクトリを作成する
 func (g GDrive) createDir(ctx context.Context, name string, parentId string) (*drive.File, error) {
-	dir := getTargetDirWithParent(ctx, name, parentId, g.client)
+	dir, err := getTargetDirWithParent(ctx, name, parentId, g.client)
+	if err != nil {
+		return nil, err
+	}
 	if dir == nil {
-		var err error
 		dir, err = g.client.Files.Create(
 			&drive.File{Name: name, Parents: []string{parentId}, MimeType: "application/vnd.google-apps.folder"}).Context(ctx).Do()
 		if err != nil {
@@ -217,7 +226,9 @@ func (g GDrive) CreateImageFile(ctx context.Context, name string, parent string,
 	if err != nil {
 		return err
 	}
-	defer local.Close()
+	defer func() {
+		_ = local.Close()
+	}()
 	channel, err := g.createDir(ctx, parent, g.imageDir.Id)
 	if err != nil {
 		return err
@@ -239,7 +250,10 @@ func (g GDrive) UploadFile(ctx context.Context, name string, filepath string) er
 	ctx, span := tracer.Start(ctx, "GDrive.UploadFile")
 	defer span.End()
 
-	f := g.targetFile(ctx, name, g.targetDir.Id)
+	f, err := g.targetFile(ctx, name, g.targetDir.Id)
+	if err != nil {
+		return fmt.Errorf("target file 検索に失敗: %w", err)
+	}
 	if f == nil {
 		return g.createOrUpdateFile(ctx, name, g.targetDir.Id, "", filepath, true)
 	} else {
@@ -256,7 +270,10 @@ func (g GDrive) UploadHtmlFile(ctx context.Context, name string, filepath string
 	ctx, span := tracer.Start(ctx, "GDrive.UploadHtmlFile")
 	defer span.End()
 
-	f := g.targetFile(ctx, name, g.htmlDir.Id)
+	f, err := g.targetFile(ctx, name, g.htmlDir.Id)
+	if err != nil {
+		return fmt.Errorf("target html file 検索に失敗: %w", err)
+	}
 	if f == nil {
 		return g.createOrUpdateFile(ctx, name, g.htmlCreateParentID(), "", filepath, true)
 	} else {
@@ -264,7 +281,7 @@ func (g GDrive) UploadHtmlFile(ctx context.Context, name string, filepath string
 	}
 }
 
-func (g GDrive) targetFile(ctx context.Context, filename, dirid string) *drive.File {
+func (g GDrive) targetFile(ctx context.Context, filename, dirid string) (*drive.File, error) {
 	if g.getTargetFileFn != nil {
 		return g.getTargetFileFn(ctx, filename, dirid)
 	}

--- a/client/gdrive_test.go
+++ b/client/gdrive_test.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"go.opentelemetry.io/otel"
@@ -56,8 +57,8 @@ func TestGDrive_UploadHtmlFile_CreateUsesHtmlDirAsParent(t *testing.T) {
 	var gotParent string
 	g := GDrive{
 		htmlDir: &drive.File{Id: "html-dir-id"},
-		getTargetFileFn: func(ctx context.Context, filename, dirid string) *drive.File {
-			return nil
+		getTargetFileFn: func(ctx context.Context, filename, dirid string) (*drive.File, error) {
+			return nil, nil
 		},
 		createFileFn: func(ctx context.Context, name, parent, filepath string) error {
 			called = true
@@ -84,8 +85,8 @@ func TestGDrive_UploadHtmlFile_UpdateWhenFileExists(t *testing.T) {
 	updateCalled := false
 	g := GDrive{
 		htmlDir: &drive.File{Id: "html-dir-id"},
-		getTargetFileFn: func(ctx context.Context, filename, dirid string) *drive.File {
-			return &drive.File{Id: "existing-file-id", Name: filename}
+		getTargetFileFn: func(ctx context.Context, filename, dirid string) (*drive.File, error) {
+			return &drive.File{Id: "existing-file-id", Name: filename}, nil
 		},
 		createFileFn: func(ctx context.Context, name, parent, filepath string) error {
 			createCalled = true
@@ -108,5 +109,47 @@ func TestGDrive_UploadHtmlFile_UpdateWhenFileExists(t *testing.T) {
 	}
 	if !updateCalled {
 		t.Fatal("updateFile was not called")
+	}
+}
+
+func TestGDrive_UploadFile_TargetFileSearchError(t *testing.T) {
+	tracer = otel.GetTracerProvider().Tracer("client-test")
+
+	expected := errors.New("drive api temporary failure")
+	g := GDrive{
+		targetDir: &drive.File{Id: "target-dir-id"},
+		getTargetFileFn: func(ctx context.Context, filename, dirid string) (*drive.File, error) {
+			return nil, expected
+		},
+		createFileFn: func(ctx context.Context, name, parent, filepath string) error {
+			t.Fatal("createFile should not be called when targetFile search fails")
+			return nil
+		},
+	}
+
+	err := g.UploadFile(context.Background(), "test.txt", "/tmp/test.txt")
+	if err == nil {
+		t.Fatal("expected error when targetFile search fails, got nil")
+	}
+}
+
+func TestGDrive_UploadHtmlFile_TargetFileSearchError(t *testing.T) {
+	tracer = otel.GetTracerProvider().Tracer("client-test")
+
+	expected := errors.New("drive api temporary failure")
+	g := GDrive{
+		htmlDir: &drive.File{Id: "html-dir-id"},
+		getTargetFileFn: func(ctx context.Context, filename, dirid string) (*drive.File, error) {
+			return nil, expected
+		},
+		createFileFn: func(ctx context.Context, name, parent, filepath string) error {
+			t.Fatal("createFile should not be called when targetFile search fails")
+			return nil
+		},
+	}
+
+	err := g.UploadHtmlFile(context.Background(), "index.html", "/tmp/index.html")
+	if err == nil {
+		t.Fatal("expected error when targetFile search fails, got nil")
 	}
 }

--- a/client/handlers.go
+++ b/client/handlers.go
@@ -156,7 +156,9 @@ func downloadSingleImageFile(ctx context.Context, client fileContextGetter, chan
 	if err != nil {
 		return "", fmt.Errorf("attachment index=%d stage=create_local_file: %w", index, err)
 	}
-	defer localFile.Close()
+	defer func() {
+		_ = localFile.Close()
+	}()
 
 	if err := client.GetFileContext(ctx, file.URLPrivateDownload, localFile); err != nil {
 		return "", fmt.Errorf("attachment index=%d stage=download url=%s: %w", index, file.URLPrivateDownload, err)

--- a/client/link_preview.go
+++ b/client/link_preview.go
@@ -133,7 +133,9 @@ func defaultLinkPreviewFetcher(ctx context.Context, rawURL string) (*LinkPreview
 	if err != nil {
 		return nil, fmt.Errorf("request failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return nil, fmt.Errorf("unexpected status: %d", resp.StatusCode)


### PR DESCRIPTION
## Summary
Google Drive検索でAPIエラーが発生した場合に `nil` 扱いせず、呼び出し元へ `error` を伝播するように修正しました。あわせて既存のlint指摘（`errcheck` / `staticcheck`）を解消しています。

## Changes
- `getTargetDir` / `getTargetDirWithParent` / `getTargetFile` の返り値を `(*drive.File, error)` に変更
- `NewGDrive` / `createDir` / `UploadFile` / `UploadHtmlFile` で「未存在」と「API失敗」を分岐
- `getTargetFileFn` モック型を `(*drive.File, error)` に更新
- 検索API失敗時のエラー伝播を確認する異常系テストを追加
- 既存lint対応として `Close()` の戻り値未チェック箇所と `WriteString(fmt.Sprintf(...))` を修正

## Validation
- `go fmt ./...`
- `go test ./...`
- `golangci-lint run`

## Related Issue
- Closes #72
