### PR TITLE
Issue #73 CSS初期化のos.Statエラー判定を厳密化

### DIFF
--- a/client/bot.go
+++ b/client/bot.go
@@ -140,8 +140,17 @@ func initHtml(config Config) error {
 	if err := os.MkdirAll(path.Join(config.BaseDir, HtmlDir), os.ModePerm); err != nil {
 		return fmt.Errorf("HTMLディレクトリの作成に失敗： %v", err)
 	}
-	// CSSFileコピー（なければ）
-	if _, err := os.Stat(path.Join(config.BaseDir, HtmlDir, CSSFile)); err != nil {
+	return ensureCSSFile(config.BaseDir, os.Stat)
+}
+
+func ensureCSSFile(baseDir string, statFn func(string) (os.FileInfo, error)) error {
+	cssPath := path.Join(baseDir, HtmlDir, CSSFile)
+	// CSSFileコピー（未存在の場合のみ）
+	if _, err := statFn(cssPath); err != nil {
+		if !os.IsNotExist(err) {
+			return fmt.Errorf("CSS %s の状態確認に失敗： %v", CSSFile, err)
+		}
+
 		src, err := templateFiles.Open(path.Join(TemplateDir, CSSFile))
 		if err != nil {
 			return fmt.Errorf("CSS %s のオープンに失敗： %v", CSSFile, err)
@@ -149,7 +158,7 @@ func initHtml(config Config) error {
 		defer func() {
 			_ = src.Close()
 		}()
-		dst, err := os.Create(path.Join(config.BaseDir, HtmlDir, CSSFile))
+		dst, err := os.Create(cssPath)
 		if err != nil {
 			return fmt.Errorf("CSS %s の作成に失敗： %v", CSSFile, err)
 		}

--- a/client/bot_test.go
+++ b/client/bot_test.go
@@ -1,0 +1,50 @@
+package client
+
+import (
+	"os"
+	"path"
+	"strings"
+	"testing"
+)
+
+func TestEnsureCSSFile_CopyWhenNotExist(t *testing.T) {
+	baseDir := t.TempDir()
+	if err := os.MkdirAll(path.Join(baseDir, HtmlDir), os.ModePerm); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+
+	if err := ensureCSSFile(baseDir, os.Stat); err != nil {
+		t.Fatalf("ensureCSSFile() error = %v", err)
+	}
+
+	cssPath := path.Join(baseDir, HtmlDir, CSSFile)
+	content, err := os.ReadFile(cssPath)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if len(content) == 0 {
+		t.Fatalf("CSS file is empty")
+	}
+}
+
+func TestEnsureCSSFile_ReturnsErrorWhenStatErrorIsNotNotExist(t *testing.T) {
+	baseDir := t.TempDir()
+	if err := os.MkdirAll(path.Join(baseDir, HtmlDir), os.ModePerm); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+
+	err := ensureCSSFile(baseDir, func(_ string) (os.FileInfo, error) {
+		return nil, os.ErrPermission
+	})
+	if err == nil {
+		t.Fatalf("ensureCSSFile() error = nil, want non-nil")
+	}
+	if !strings.Contains(err.Error(), "状態確認に失敗") {
+		t.Fatalf("ensureCSSFile() error = %v, want status check failure", err)
+	}
+
+	cssPath := path.Join(baseDir, HtmlDir, CSSFile)
+	if _, statErr := os.Stat(cssPath); !os.IsNotExist(statErr) {
+		t.Fatalf("CSS file should not be created when stat fails: %v", statErr)
+	}
+}


### PR DESCRIPTION
## Summary
Issue #73 の対応として、CSS初期化時の `os.Stat` エラー判定を `os.IsNotExist` に限定しました。

## Changes
- `initHtml` から `ensureCSSFile` を呼び出す構成に変更
- `ensureCSSFile` で以下を実装
  - `os.IsNotExist(err)` の場合のみテンプレートCSSをコピー
  - それ以外の `os.Stat` エラーは明示的にエラー返却
- `client/bot_test.go` を追加
  - 未存在時にコピーされるテスト
  - 非 `NotExist` エラー時にコピーせず失敗するテスト

## Validation
- `go fmt ./...`
- `go test ./...`
- `golangci-lint run`

すべてローカルで成功。

## Related Issue
- Closes #73
