### PR TITLE
Issue #69 /show-files に最終更新日時と件数を追加

### DIFF
--- a/client/handlers.go
+++ b/client/handlers.go
@@ -10,6 +10,7 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -23,8 +24,16 @@ import (
 
 var channelNamePattern = regexp.MustCompile(`^[a-z0-9_-]+$`)
 
+const showFilesTimeLayout = "2006-01-02 15:04:05"
+
 type fileContextGetter interface {
 	GetFileContext(ctx context.Context, downloadURL string, writer io.Writer) error
+}
+
+type showFileEntry struct {
+	name      string
+	hasHTML   bool
+	updatedAt time.Time
 }
 
 // MessageEventHandler チャンネルごとのメッセージ受信ハンドラー: MessageEventHandler はメッセージイベントを処理します。
@@ -266,24 +275,13 @@ func executeCommand(ctx context.Context, ev slack.SlashCommand, channels *Channe
 			msg = fmt.Sprintf("%v\nError: %v", msg, err.Error())
 		}
 	} else if strings.HasPrefix(ev.Command, "/show-files") {
-		msg = "Files are ..."
-		dirReader, err := os.ReadDir(basedir)
+		built, err := buildShowFilesMessage(basedir)
 		if err != nil {
 			fmt.Printf("######### : Got error %v\n", err)
-			msg = fmt.Sprintf("%v\nError: %v", msg, err.Error())
+			msg = fmt.Sprintf("Files are ...\nError: %v", err.Error())
+		} else {
+			msg = built
 		}
-		var files []string
-		htmls := htmlFileNames(basedir)
-		for _, entry := range dirReader {
-			if file, ok := strings.CutSuffix(entry.Name(), ".jsonl"); ok {
-				if _, ok := htmls[file]; ok {
-					files = append(files, fmt.Sprintf(":o: %s", entry.Name()))
-				} else {
-					files = append(files, fmt.Sprintf(":x: %s", entry.Name()))
-				}
-			}
-		}
-		msg = fmt.Sprintf("%s\n%s\n", msg, strings.Join(files, "\n"))
 	} else if strings.HasPrefix(ev.Command, "/make-md") {
 		msg = "Created markdown zip file"
 		channelName, since, err := resolveMakeMDParams(ev)
@@ -439,6 +437,55 @@ func htmlFileNames(basedir string) map[string]bool {
 		}
 	}
 	return files
+}
+
+func buildShowFilesMessage(basedir string) (string, error) {
+	files, err := collectShowFileEntries(basedir)
+	if err != nil {
+		return "", err
+	}
+
+	lines := []string{"Files are ..."}
+	total := len(files)
+	shown := len(files)
+	for _, f := range files {
+		status := ":x:"
+		if f.hasHTML {
+			status = ":o:"
+		}
+		lines = append(lines, fmt.Sprintf("%s %s (updated: %s)", status, f.name, f.updatedAt.Format(showFilesTimeLayout)))
+	}
+	lines = append(lines, fmt.Sprintf("count: %d/%d", total, shown))
+	return strings.Join(lines, "\n") + "\n", nil
+}
+
+func collectShowFileEntries(basedir string) ([]showFileEntry, error) {
+	dirReader, err := os.ReadDir(basedir)
+	if err != nil {
+		return nil, err
+	}
+	htmls := htmlFileNames(basedir)
+	files := make([]showFileEntry, 0)
+	for _, entry := range dirReader {
+		fileBase, ok := strings.CutSuffix(entry.Name(), ".jsonl")
+		if !ok {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get file info: %w", err)
+		}
+		files = append(files, showFileEntry{
+			name:      entry.Name(),
+			hasHTML:   htmls[fileBase],
+			updatedAt: info.ModTime(),
+		})
+	}
+
+	sort.Slice(files, func(i, j int) bool {
+		return files[i].name < files[j].name
+	})
+	return files, nil
 }
 
 func ChannelArchiveHandler(channels *Channels, gdrive *GDrive) socketmode.SocketmodeHandlerFunc {

--- a/client/handlers.go
+++ b/client/handlers.go
@@ -24,7 +24,7 @@ import (
 
 var channelNamePattern = regexp.MustCompile(`^[a-z0-9_-]+$`)
 
-const showFilesTimeLayout = "2006-01-02 15:04:05"
+const showFilesTimeLayout = "2006-01-02 15:04:05 MST"
 
 type fileContextGetter interface {
 	GetFileContext(ctx context.Context, downloadURL string, writer io.Writer) error

--- a/client/handlers_test.go
+++ b/client/handlers_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -488,6 +489,30 @@ func TestBuildShowFilesMessage_IncludesUpdatedAtAndCount(t *testing.T) {
 	}
 	if strings.Index(msg, "alpha.jsonl") > strings.Index(msg, "zeta.jsonl") {
 		t.Fatalf("message should be sorted by file name: %q", msg)
+	}
+}
+
+func TestBuildShowFilesMessage_ReturnsErrorWhenBaseDirMissing(t *testing.T) {
+	_, err := buildShowFilesMessage(filepath.Join(t.TempDir(), "missing"))
+	if err == nil {
+		t.Fatalf("buildShowFilesMessage() error = nil, want non-nil")
+	}
+}
+
+func TestExecuteCommand_ShowFilesErrorIncludesMessage(t *testing.T) {
+	msg := executeCommand(
+		context.Background(),
+		slack.SlashCommand{Command: "/show-files"},
+		nil,
+		nil,
+		filepath.Join(t.TempDir(), "missing"),
+		nil,
+	)
+	if !strings.Contains(msg, "Files are ...") {
+		t.Fatalf("executeCommand() missing header: %q", msg)
+	}
+	if !strings.Contains(msg, "Error:") {
+		t.Fatalf("executeCommand() missing error line: %q", msg)
 	}
 }
 

--- a/client/handlers_test.go
+++ b/client/handlers_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"io"
+	"os"
+	"path"
 	"strings"
 	"testing"
 	"time"
@@ -432,6 +434,60 @@ func TestSkipMessage(t *testing.T) {
 				t.Fatalf("skipMessage() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestBuildShowFilesMessage_IncludesUpdatedAtAndCount(t *testing.T) {
+	baseDir := t.TempDir()
+	if err := os.WriteFile(path.Join(baseDir, "zeta.jsonl"), []byte("{}"), 0644); err != nil {
+		t.Fatalf("WriteFile(zeta) error = %v", err)
+	}
+	if err := os.WriteFile(path.Join(baseDir, "alpha.jsonl"), []byte("{}"), 0644); err != nil {
+		t.Fatalf("WriteFile(alpha) error = %v", err)
+	}
+	if err := os.WriteFile(path.Join(baseDir, "notes.txt"), []byte("ignore"), 0644); err != nil {
+		t.Fatalf("WriteFile(notes) error = %v", err)
+	}
+	if err := os.MkdirAll(path.Join(baseDir, HtmlDir), os.ModePerm); err != nil {
+		t.Fatalf("MkdirAll(html) error = %v", err)
+	}
+	if err := os.WriteFile(path.Join(baseDir, HtmlDir, "alpha.html"), []byte("<html></html>"), 0644); err != nil {
+		t.Fatalf("WriteFile(alpha.html) error = %v", err)
+	}
+
+	alphaTime := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	zetaTime := time.Date(2026, 1, 3, 4, 5, 6, 0, time.UTC)
+	if err := os.Chtimes(path.Join(baseDir, "alpha.jsonl"), alphaTime, alphaTime); err != nil {
+		t.Fatalf("Chtimes(alpha) error = %v", err)
+	}
+	if err := os.Chtimes(path.Join(baseDir, "zeta.jsonl"), zetaTime, zetaTime); err != nil {
+		t.Fatalf("Chtimes(zeta) error = %v", err)
+	}
+
+	msg, err := buildShowFilesMessage(baseDir)
+	if err != nil {
+		t.Fatalf("buildShowFilesMessage() error = %v", err)
+	}
+	alphaExpected := alphaTime.In(time.Local).Format(showFilesTimeLayout)
+	zetaExpected := zetaTime.In(time.Local).Format(showFilesTimeLayout)
+
+	if !strings.Contains(msg, "Files are ...") {
+		t.Fatalf("message missing header: %q", msg)
+	}
+	if !strings.Contains(msg, ":o: alpha.jsonl (updated: "+alphaExpected+")") {
+		t.Fatalf("message missing alpha line: %q", msg)
+	}
+	if !strings.Contains(msg, ":x: zeta.jsonl (updated: "+zetaExpected+")") {
+		t.Fatalf("message missing zeta line: %q", msg)
+	}
+	if !strings.Contains(msg, "count: 2/2") {
+		t.Fatalf("message missing count: %q", msg)
+	}
+	if strings.Contains(msg, "notes.txt") {
+		t.Fatalf("message should not include non-jsonl file: %q", msg)
+	}
+	if strings.Index(msg, "alpha.jsonl") > strings.Index(msg, "zeta.jsonl") {
+		t.Fatalf("message should be sorted by file name: %q", msg)
 	}
 }
 


### PR DESCRIPTION
## Summary
Issue #69 対応として `/show-files` の出力に最終更新日時と件数を追加しました。

## Changes
- `/show-files` の生成ロジックを `buildShowFilesMessage` / `collectShowFileEntries` に分離
- 各 `.jsonl` 行に最終更新日時を追加
  - 形式: `updated: YYYY-MM-DD HH:MM:SS`
- 出力末尾に件数を追加
  - 形式: `count: <total>/<shown>`
- ファイル名昇順で安定表示
- `client/handlers_test.go` に表示フォーマット検証テストを追加
  - 更新日時表示
  - 件数表示
  - `:o:` / `:x:` 判定
  - `.jsonl` 以外を除外
  - ソート順

## Validation
- `go fmt ./...`
- `go test ./...`
- `golangci-lint run`

すべてローカルで成功。

## Related Issue
- Closes #69
